### PR TITLE
chore(seed): add default agent records

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,5 @@
 // prisma/seed.ts
-import { PrismaClient, Role } from "@prisma/client";
+import { PrismaClient, Role, AgentType } from "@prisma/client";
 import bcrypt from "bcryptjs";
 
 const prisma = new PrismaClient();
@@ -7,7 +7,7 @@ const prisma = new PrismaClient();
 async function main() {
   const passwordHash = await bcrypt.hash("teste01@123", 10);
 
-  await prisma.user.upsert({
+  const admin = await prisma.user.upsert({
     where: { email: "admin@example.com" },
     update: {},
     create: {
@@ -19,6 +19,48 @@ async function main() {
   });
 
   console.log("✅ Usuário seed criado: admin@example.com / teste01@123");
+
+  // --------- Agents ---------
+  await prisma.agent.upsert({
+    where: { id: "agent-secretaria" },
+    update: {},
+    create: {
+      id: "agent-secretaria",
+      nome: "Anne",
+      tipo: AgentType.SECRETARIA,
+      persona: "Agente de secretária que gerencia documentos e matrículas",
+      ownerId: admin.id,
+      tags: { create: [{ tag: "matricula" }] },
+    },
+  });
+
+  await prisma.agent.upsert({
+    where: { id: "agent-sdr" },
+    update: {},
+    create: {
+      id: "agent-sdr",
+      nome: "SOFIA",
+      tipo: AgentType.SDR,
+      persona: "Agente SDR focada em prospecção de leads",
+      ownerId: admin.id,
+      tags: { create: [{ tag: "getWeather" }] },
+    },
+  });
+
+  await prisma.agent.upsert({
+    where: { id: "agent-financeiro" },
+    update: {},
+    create: {
+      id: "agent-financeiro",
+      nome: "BILL",
+      tipo: AgentType.FINANCEIRO,
+      persona: "Agente financeiro responsável por contas e recebíveis",
+      ownerId: admin.id,
+      tags: { create: [{ tag: "getWeather" }] },
+    },
+  });
+
+  console.log("✅ Agentes seed criados: SECRETARIA, SDR, FINANCEIRO");
 }
 
 main()


### PR DESCRIPTION
## Summary
- seed default SECRETARIA, SDR and FINANCEIRO agents with personas and sample tool tags

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: formatting and lint errors in existing files)*
- `npm run typecheck` *(fails: TypeScript errors in existing source)*
- `npx prisma db seed` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5fa4e9708328b119293bb9d1b3ae