### PR TITLE
feat: export secretary and sdr tools

### DIFF
--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,53 +1,62 @@
-import { Agent } from "@voltagent/core";
 import { openai } from "@ai-sdk/openai";
+import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
-import { prisma } from "../utils/prisma";
 import { makeQdrantRetriever } from "../retriever/qdrant-retriever";
-import { registrationStudentsTool } from "../tools/secretary"; // exemplo
+import { registrationStudentsTool } from "../tools"; // exemplo
+import { prisma } from "../utils/prisma";
 
 function toolsForType(tipo: string) {
-  switch (tipo) {
-    case "SECRETARIA": return [registrationStudentsTool];
-    default: return [];
-  }
+	switch (tipo) {
+		case "SECRETARIA":
+			return [registrationStudentsTool];
+		default:
+			return [];
+	}
 }
 
 async function buildInstructions(agentId: string) {
-  const agent = await prisma.agent.findUnique({ where: { id: agentId } });
-  if (!agent) throw new Error("agent not found");
+	const agent = await prisma.agent.findUnique({ where: { id: agentId } });
+	if (!agent) throw new Error("agent not found");
 
-  let persona = agent.persona ?? "";
-  if (!persona && agent.parentId && agent.herdaPersonaDoPai) {
-    const parent = await prisma.agent.findUnique({ where: { id: agent.parentId } });
-    if (parent?.persona) persona = parent.persona;
-  }
+	let persona = agent.persona ?? "";
+	if (!persona && agent.parentId && agent.herdaPersonaDoPai) {
+		const parent = await prisma.agent.findUnique({
+			where: { id: agent.parentId },
+		});
+		if (parent?.persona) persona = parent.persona;
+	}
 
-  // (opcional) incorporar títulos das RULE_OVERRIDE
-  const ruleLinks = await prisma.agentDocument.findMany({
-    where: { agentId, role: "RULE_OVERRIDE" },
-    include: { document: true },
-  });
-  const rulesText = ruleLinks.map(l => `\n[REGRA: ${l.document.name}]`).join("");
+	// (opcional) incorporar títulos das RULE_OVERRIDE
+	const ruleLinks = await prisma.agentDocument.findMany({
+		where: { agentId, role: "RULE_OVERRIDE" },
+		include: { document: true },
+	});
+	const rulesText = ruleLinks
+		.map((l) => `\n[REGRA: ${l.document.name}]`)
+		.join("");
 
-  return `${persona}${rulesText}`;
+	return `${persona}${rulesText}`;
 }
 
 export async function buildAgentFromDB(agentId: string) {
-  const row = await prisma.agent.findUnique({ where: { id: agentId } });
-  if (!row) throw new Error("agent not found");
+	const row = await prisma.agent.findUnique({ where: { id: agentId } });
+	if (!row) throw new Error("agent not found");
 
-  const instructions = await buildInstructions(agentId);
-  const tools = toolsForType(row.tipo);
+	const instructions = await buildInstructions(agentId);
+	const tools = toolsForType(row.tipo);
 
-  return new Agent({
-    name: row.nome,
-    description: `Agente ${row.tipo}`,
-    instructions,
-    llm: new VercelAIProvider(),
-    model: openai("gpt-4o-mini"),
-    tools,
-    retriever: makeQdrantRetriever(row.id),   // 🔑 RAG por agente
-    subAgents: [],
-    userContext: new Map([["environment", "production"], ["agentId", row.id]]),
-  });
+	return new Agent({
+		name: row.nome,
+		description: `Agente ${row.tipo}`,
+		instructions,
+		llm: new VercelAIProvider(),
+		model: openai("gpt-4o-mini"),
+		tools,
+		retriever: makeQdrantRetriever(row.id), // 🔑 RAG por agente
+		subAgents: [],
+		userContext: new Map([
+			["environment", "production"],
+			["agentId", row.id],
+		]),
+	});
 }

--- a/src/agents/secretary.ts
+++ b/src/agents/secretary.ts
@@ -3,31 +3,31 @@ import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { scriptGeral } from "../scripts/geral";
 import { SecretaryScript } from "../scripts/secretary-script";
-import { registrationStudentsTool } from "../tools/secretary";
+import { registrationStudentsTool } from "../tools";
 
 export const SecretaryAgent = new Agent({
-  name: "Anne",
-  instructions: `${SecretaryScript} ${scriptGeral}`,
-  llm: new VercelAIProvider(),
-  model: openai("gpt-4o-mini"),
-  tools: [registrationStudentsTool],
-  subAgents: [],
-  purpose: "Agente de secretária que faz a gestão de documentos e matrículas",
-  userContext: new Map([["environment", "production"]]),
+	name: "Anne",
+	instructions: `${SecretaryScript} ${scriptGeral}`,
+	llm: new VercelAIProvider(),
+	model: openai("gpt-4o-mini"),
+	tools: [registrationStudentsTool],
+	subAgents: [],
+	purpose: "Agente de secretária que faz a gestão de documentos e matrículas",
+	userContext: new Map([["environment", "production"]]),
 });
 
 // aquui é dado a resposta // retorne a resposta inteira e quebre em chunks
 export async function SecretaryChat(
-  input: string,
-  userId: string,
-  conversationId: string
+	input: string,
+	userId: string,
+	conversationId: string,
 ) {
-  console.log(`User: ${input}`);
-  // Use streamText for interactive responses
-  const result = await SecretaryAgent.generateText(input, {
-    userId,
-    conversationId,
-  });
+	console.log(`User: ${input}`);
+	// Use streamText for interactive responses
+	const result = await SecretaryAgent.generateText(input, {
+		userId,
+		conversationId,
+	});
 
-  return result;
+	return result;
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,2 +1,4 @@
 // Export all tools from this directory
 export { weatherTool } from "./weather";
+export * from "./secretary";
+export * from "./sdr";

--- a/src/tools/sdr/index.ts
+++ b/src/tools/sdr/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for SDR tools
+export {};


### PR DESCRIPTION
## Summary
- expose secretary and SDR tool modules via the tools index
- update agents to import tools from central index for consistency
- add placeholder module for SDR tools

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx biome check src/tools/index.ts src/agents/secretary.ts src/agents/factory.ts src/tools/sdr/index.ts`
- `npm run typecheck` *(fails: Parameter 'l' implicitly has an 'any' type, Module '@prisma/client' has no exported member, Cannot find module 'openai', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae5fa4015883288211211db2058dc1