### PR TITLE
feat: combine SDR agent scripts

### DIFF
--- a/src/agents/sdr.ts
+++ b/src/agents/sdr.ts
@@ -1,31 +1,32 @@
 import { openai } from "@ai-sdk/openai";
 import { Agent, InMemoryStorage } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
+import { scriptGeral } from "../scripts/geral";
 import { SRDScript } from "../scripts/sdr-script";
 
 export const SDRAgent = new Agent({
-  name: "SOFIA",
-  instructions: SRDScript,
-  llm: new VercelAIProvider(),
-  model: openai("gpt-4o-mini"),
-  tools: [],
-  subAgents: [],
-  purpose: "Agente de SRD",
-  userContext: new Map([["environment", "production"]]),
+	name: "SOFIA",
+	instructions: `${SRDScript} ${scriptGeral}`,
+	llm: new VercelAIProvider(),
+	model: openai("gpt-4o-mini"),
+	tools: [],
+	subAgents: [],
+	purpose: "Agente de SRD",
+	userContext: new Map([["environment", "production"]]),
 });
 
 // aquui é dado a resposta // retorne a resposta inteira e quebre em chunks
 export async function SDRChat(
-  input: string,
-  userId: string,
-  conversationId: string
+	input: string,
+	userId: string,
+	conversationId: string,
 ) {
-  console.log(`User: ${input}`);
-  // Use streamText for interactive responses
-  const result = await SDRAgent.generateText(input, {
-    userId,
-    conversationId,
-  });
+	console.log(`User: ${input}`);
+	// Use streamText for interactive responses
+	const result = await SDRAgent.generateText(input, {
+		userId,
+		conversationId,
+	});
 
-  return result;
+	return result;
 }


### PR DESCRIPTION
## Summary
- include shared instructions by importing `scriptGeral`
- combine general and SDR-specific scripts in SDR agent's instructions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx biome check src/agents/sdr.ts`
- `npm run lint` *(fails: Some errors were emitted while running checks)*
- `npm run typecheck` *(fails: TS errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5f8bf95083289d91f319a506bda3