### PR TITLE
feat: add role-specific tools

### DIFF
--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,14 +1,37 @@
-import { Agent } from "@voltagent/core";
 import { openai } from "@ai-sdk/openai";
+import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
-import { prisma } from "../utils/prisma";
 import { makeQdrantRetriever } from "../retriever/qdrant-retriever";
-import { registrationStudentsTool } from "../tools/secretary"; // exemplo
+import { financeiroTool } from "../tools/financeiro";
+import { logisticaTool } from "../tools/logistica";
+import { posVendaTool } from "../tools/pos-venda";
+import { rhTool } from "../tools/rh";
+import { sdrLeadTool } from "../tools/sdr";
+import { registrationStudentsTool } from "../tools/secretary";
+import { suporteTecnicoTool } from "../tools/suporte-tecnico";
+import { vendedorTool } from "../tools/vendedor";
+import { prisma } from "../utils/prisma";
 
 function toolsForType(tipo: string) {
   switch (tipo) {
-    case "SECRETARIA": return [registrationStudentsTool];
-    default: return [];
+    case "SECRETARIA":
+      return [registrationStudentsTool];
+    case "SDR":
+      return [sdrLeadTool];
+    case "POS_VENDA":
+      return [posVendaTool];
+    case "SUPORTE_TECNICO":
+      return [suporteTecnicoTool];
+    case "VENDEDOR":
+      return [vendedorTool];
+    case "FINANCEIRO":
+      return [financeiroTool];
+    case "LOGISTICA":
+      return [logisticaTool];
+    case "RH":
+      return [rhTool];
+    default:
+      return [];
   }
 }
 
@@ -46,7 +69,7 @@ export async function buildAgentFromDB(agentId: string) {
     llm: new VercelAIProvider(),
     model: openai("gpt-4o-mini"),
     tools,
-    retriever: makeQdrantRetriever(row.id),   // 🔑 RAG por agente
+    retriever: makeQdrantRetriever(row.id), // 🔑 RAG por agente
     subAgents: [],
     userContext: new Map([["environment", "production"], ["agentId", row.id]]),
   });

--- a/src/tools/financeiro/index.ts
+++ b/src/tools/financeiro/index.ts
@@ -1,0 +1,13 @@
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
+
+export const financeiroTool = createTool({
+  name: "emitirRelatorio",
+  description: "Emite um relatório financeiro de exemplo",
+  parameters: z.object({
+    mes: z.string().describe("mês de referência"),
+  }),
+  execute: async ({ mes }) => {
+    return { result: `Relatório financeiro de ${mes} gerado` };
+  },
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,2 +1,10 @@
 // Export all tools from this directory
 export { weatherTool } from "./weather";
+export { registrationStudentsTool } from "./secretary";
+export { sdrLeadTool } from "./sdr";
+export { posVendaTool } from "./pos-venda";
+export { suporteTecnicoTool } from "./suporte-tecnico";
+export { vendedorTool } from "./vendedor";
+export { financeiroTool } from "./financeiro";
+export { logisticaTool } from "./logistica";
+export { rhTool } from "./rh";

--- a/src/tools/logistica/index.ts
+++ b/src/tools/logistica/index.ts
@@ -1,0 +1,13 @@
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
+
+export const logisticaTool = createTool({
+  name: "agendarEntrega",
+  description: "Agenda uma entrega de exemplo",
+  parameters: z.object({
+    pedido: z.string().describe("número do pedido"),
+  }),
+  execute: async ({ pedido }) => {
+    return { result: `Entrega do pedido ${pedido} agendada` };
+  },
+});

--- a/src/tools/pos-venda/index.ts
+++ b/src/tools/pos-venda/index.ts
@@ -1,0 +1,13 @@
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
+
+export const posVendaTool = createTool({
+  name: "followUp",
+  description: "Ferramenta de exemplo para pós-venda",
+  parameters: z.object({
+    ticket: z.string().describe("número do ticket"),
+  }),
+  execute: async ({ ticket }) => {
+    return { result: `Follow-up registrado para o ticket ${ticket}` };
+  },
+});

--- a/src/tools/rh/index.ts
+++ b/src/tools/rh/index.ts
@@ -1,0 +1,13 @@
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
+
+export const rhTool = createTool({
+  name: "registrarFuncionario",
+  description: "Registra um funcionário de exemplo",
+  parameters: z.object({
+    nome: z.string().describe("nome do funcionário"),
+  }),
+  execute: async ({ nome }) => {
+    return { result: `Funcionário ${nome} registrado` };
+  },
+});

--- a/src/tools/sdr/index.ts
+++ b/src/tools/sdr/index.ts
@@ -1,0 +1,13 @@
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
+
+export const sdrLeadTool = createTool({
+  name: "qualifyLead",
+  description: "Ferramenta de exemplo para qualificação de leads",
+  parameters: z.object({
+    leadName: z.string().describe("nome do lead"),
+  }),
+  execute: async ({ leadName }) => {
+    return { result: `Lead ${leadName} qualificado` };
+  },
+});

--- a/src/tools/suporte-tecnico/index.ts
+++ b/src/tools/suporte-tecnico/index.ts
@@ -1,0 +1,13 @@
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
+
+export const suporteTecnicoTool = createTool({
+  name: "diagnosticarProblema",
+  description: "Ferramenta de exemplo para suporte técnico",
+  parameters: z.object({
+    issue: z.string().describe("descrição do problema"),
+  }),
+  execute: async ({ issue }) => {
+    return { result: `Problema '${issue}' registrado` };
+  },
+});

--- a/src/tools/vendedor/index.ts
+++ b/src/tools/vendedor/index.ts
@@ -1,0 +1,13 @@
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
+
+export const vendedorTool = createTool({
+  name: "gerarCotacao",
+  description: "Gera uma cotação de exemplo",
+  parameters: z.object({
+    produto: z.string().describe("nome do produto"),
+  }),
+  execute: async ({ produto }) => {
+    return { result: `Cotação gerada para ${produto}` };
+  },
+});


### PR DESCRIPTION
## Summary
- add example tools for all agent roles under `src/tools`
- export tools and map each AgentType to its tools in the agent factory

## Testing
- `npm run lint` *(fails: formatting errors in existing files)*
- `npm run typecheck` *(fails: type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5f87f8008328b1ece76874c467ec