### PR TITLE
feat: add hono context typing to endpoints

### DIFF
--- a/src/endpoints/agent-trainning.ts
+++ b/src/endpoints/agent-trainning.ts
@@ -1,47 +1,48 @@
-import { CustomEndpointDefinition } from "@voltagent/core";
-import { prisma } from "../utils/prisma";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { startAgentTraining } from "../services/agent-trainning";
+import { prisma } from "../utils/prisma";
 
 export const agentTrainEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/agents/:id/train",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId)
-        return c.json({ success: false, message: "missing userId" }, 401);
-      const id = c.req.param("id");
+	{
+		path: "/api/agents/:id/train",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
+			const id = c.req.param("id");
 
-      const agent = await prisma.agent.findUnique({ where: { id } });
-      if (!agent)
-        return c.json({ success: false, message: "agent not found" }, 404);
-      if (agent.ownerId !== userId)
-        return c.json({ success: false, message: "forbidden" }, 403);
+			const agent = await prisma.agent.findUnique({ where: { id } });
+			if (!agent)
+				return c.json({ success: false, message: "agent not found" }, 404);
+			if (agent.ownerId !== userId)
+				return c.json({ success: false, message: "forbidden" }, 403);
 
-      const job = await prisma.trainingJob.create({
-        data: { agentId: id, status: "PENDING" },
-      });
+			const job = await prisma.trainingJob.create({
+				data: { agentId: id, status: "PENDING" },
+			});
 
-      startAgentTraining(job.id).catch(async (err) => {
-        await prisma.trainingJob.update({
-          where: { id: job.id },
-          data: { status: "FAILED", error: String(err).slice(0, 2000) },
-        });
-      });
+			startAgentTraining(job.id).catch(async (err: unknown) => {
+				await prisma.trainingJob.update({
+					where: { id: job.id },
+					data: { status: "FAILED", error: String(err).slice(0, 2000) },
+				});
+			});
 
-      return c.json({ success: true, jobId: job.id });
-    },
-  },
-  {
-    path: "/api/agents/:id/train/status",
-    method: "get" as const,
-    handler: async (c: any) => {
-      const id = c.req.param("id");
-      const job = await prisma.trainingJob.findFirst({
-        where: { agentId: id },
-        orderBy: { createdAt: "desc" },
-      });
-      return c.json({ success: true, job });
-    },
-  },
+			return c.json({ success: true, jobId: job.id });
+		},
+	},
+	{
+		path: "/api/agents/:id/train/status",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const id = c.req.param("id");
+			const job = await prisma.trainingJob.findFirst({
+				where: { agentId: id },
+				orderBy: { createdAt: "desc" },
+			});
+			return c.json({ success: true, job });
+		},
+	},
 ];

--- a/src/endpoints/agents-docs.ts
+++ b/src/endpoints/agents-docs.ts
@@ -1,126 +1,154 @@
+import type { CustomEndpointDefinition } from "@voltagent/core";
 // api/agent-docs.endpoints.ts
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
+import {
+	LinkPayload,
+	assertSameOwner,
+	roleFromLabel,
+	roleToLabel,
+} from "../utils/documents.helpers";
 import { prisma } from "../utils/prisma";
-import { roleToLabel, LinkPayload, assertSameOwner, roleFromLabel } from "../utils/documents.helpers";
 
 export const agentDocumentEndpoints: CustomEndpointDefinition[] = [
-  // LISTAR documentos vinculados a um agente
-  {
-    path: "/api/agents/:agentId/documents",
-    method: "get" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// LISTAR documentos vinculados a um agente
+	{
+		path: "/api/agents/:agentId/documents",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const agentId = c.req.param("agentId");
+			const agentId = c.req.param("agentId");
 
-      // garante que o agente é do usuário
-      const agent = await prisma.agent.findFirst({ where: { id: agentId, ownerId: userId } });
-      if (!agent) return c.json({ success: false, message: "not found" }, 404);
+			// garante que o agente é do usuário
+			const agent = await prisma.agent.findFirst({
+				where: { id: agentId, ownerId: userId },
+			});
+			if (!agent) return c.json({ success: false, message: "not found" }, 404);
 
-      const links = await prisma.agentDocument.findMany({
-        where: { agentId },
-        include: { document: true },
-        orderBy: { createdAt: "desc" },
-      });
+			const links = await prisma.agentDocument.findMany({
+				where: { agentId },
+				include: { document: true },
+				orderBy: { createdAt: "desc" },
+			});
 
-      const data = links.map((l) => ({
-        document: {
-          id: l.document.id,
-          name: l.document.name,
-          kind: l.document.kind, // pode mapear para label se preferir
-        },
-        role: roleToLabel(l.role!),
-        linkId: l.id,
-      }));
+			const data = links.map((l) => ({
+				document: {
+					id: l.document.id,
+					name: l.document.name,
+					kind: l.document.kind, // pode mapear para label se preferir
+				},
+				role: l.role ? roleToLabel(l.role) : roleToLabel("EXTRA"),
+				linkId: l.id,
+			}));
 
-      return c.json(data);
-    },
-    description: "[privada] lista vínculos documento↔agente",
-  },
+			return c.json(data);
+		},
+		description: "[privada] lista vínculos documento↔agente",
+	},
 
-  // CRIAR vínculo
-  {
-    path: "/api/agents/:agentId/documents",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// CRIAR vínculo
+	{
+		path: "/api/agents/:agentId/documents",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const agentId = c.req.param("agentId");
-      const body = await c.req.json();
-      const parsed = LinkPayload.safeParse(body);
-      if (!parsed.success) return c.json({ success: false, message: parsed.error.message }, 400);
-      const p = parsed.data;
+			const agentId = c.req.param("agentId");
+			const body = await c.req.json();
+			const parsed = LinkPayload.safeParse(body);
+			if (!parsed.success)
+				return c.json({ success: false, message: parsed.error.message }, 400);
+			const p = parsed.data;
 
-      // garante ownership de ambos
-      try {
-        await assertSameOwner(userId, agentId, p.documentId);
-      } catch (e: any) {
-        const msg = e?.message === "forbidden" ? "forbidden" : "not found";
-        return c.json({ success: false, message: msg }, msg === "forbidden" ? 403 : 404);
-      }
+			// garante ownership de ambos
+			try {
+				await assertSameOwner(userId, agentId, p.documentId);
+			} catch (e: unknown) {
+				const msg =
+					e instanceof Error && e.message === "forbidden"
+						? "forbidden"
+						: "not found";
+				return c.json(
+					{ success: false, message: msg },
+					msg === "forbidden" ? 403 : 404,
+				);
+			}
 
-      // define role padrão pelo kind do documento, caso não venha do front
-      let roleEnum = p.role ? roleFromLabel(p.role) : undefined;
-      if (!roleEnum) {
-        const doc = await prisma.document.findUnique({ where: { id: p.documentId } });
-        roleEnum =
-          doc?.kind === "SCRIPT"
-            ? "EXTRA"
-            : doc?.kind === "CSV"
-            ? "CSV"
-            : doc?.kind === "MEDIA"
-            ? "MEDIA"
-            : "EXTRA";
-      }
+			// define role padrão pelo kind do documento, caso não venha do front
+			let roleEnum = p.role ? roleFromLabel(p.role) : undefined;
+			if (!roleEnum) {
+				const doc = await prisma.document.findUnique({
+					where: { id: p.documentId },
+				});
+				roleEnum =
+					doc?.kind === "SCRIPT"
+						? "EXTRA"
+						: doc?.kind === "CSV"
+							? "CSV"
+							: doc?.kind === "MEDIA"
+								? "MEDIA"
+								: "EXTRA";
+			}
 
-      // evita duplicado (unique composto no schema)
-      const created = await prisma.agentDocument.create({
-        data: {
-          agentId,
-          documentId: p.documentId,
-          role: roleEnum,
-        },
-      });
+			// evita duplicado (unique composto no schema)
+			const created = await prisma.agentDocument.create({
+				data: {
+					agentId,
+					documentId: p.documentId,
+					role: roleEnum,
+				},
+			});
 
-      return c.json({ success: true, data: { linkId: created.id } }, 201);
-    },
-    description: "[privada] vincula documento a agente",
-  },
+			return c.json({ success: true, data: { linkId: created.id } }, 201);
+		},
+		description: "[privada] vincula documento a agente",
+	},
 
-  // REMOVER vínculo
-  {
-    path: "/api/agents/:agentId/documents/:documentId",
-    method: "delete" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// REMOVER vínculo
+	{
+		path: "/api/agents/:agentId/documents/:documentId",
+		method: "delete" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const agentId = c.req.param("agentId");
-      const documentId = c.req.param("documentId");
-      const role = c.req.query("role"); // ?role=primary|extra|csv|media|rule_override (opcional)
+			const agentId = c.req.param("agentId");
+			const documentId = c.req.param("documentId");
+			const role = c.req.query("role"); // ?role=primary|extra|csv|media|rule_override (opcional)
 
-      // ownership
-      try {
-        await assertSameOwner(userId, agentId, documentId);
-      } catch (e: any) {
-        const msg = e?.message === "forbidden" ? "forbidden" : "not found";
-        return c.json({ success: false, message: msg }, msg === "forbidden" ? 403 : 404);
-      }
+			// ownership
+			try {
+				await assertSameOwner(userId, agentId, documentId);
+			} catch (e: unknown) {
+				const msg =
+					e instanceof Error && e.message === "forbidden"
+						? "forbidden"
+						: "not found";
+				return c.json(
+					{ success: false, message: msg },
+					msg === "forbidden" ? 403 : 404,
+				);
+			}
 
-      const where: any = { agentId_documentId_role: undefined };
-      if (role) {
-        // quando tem unique([agentId, documentId, role])
-        await prisma.agentDocument.deleteMany({
-          where: { agentId, documentId, role: roleFromLabel(String(role)) },
-        });
-      } else {
-        await prisma.agentDocument.deleteMany({ where: { agentId, documentId } });
-      }
+			if (role) {
+				// quando tem unique([agentId, documentId, role])
+				await prisma.agentDocument.deleteMany({
+					where: { agentId, documentId, role: roleFromLabel(String(role)) },
+				});
+			} else {
+				await prisma.agentDocument.deleteMany({
+					where: { agentId, documentId },
+				});
+			}
 
-      return c.json({ success: true });
-    },
-    description: "[privada] desvincula documento de agente (por role, se enviado)",
-  },
+			return c.json({ success: true });
+		},
+		description:
+			"[privada] desvincula documento de agente (por role, se enviado)",
+	},
 ];

--- a/src/endpoints/agents.ts
+++ b/src/endpoints/agents.ts
@@ -1,172 +1,195 @@
-import { z } from 'zod';
-import { AgentStatus, AgentType } from '@prisma/client';
-import { CustomEndpointDefinition } from '@voltagent/core';
-import { prisma } from '../utils/prisma';
+import type { AgentStatus, AgentType } from "@prisma/client";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
+import { z } from "zod";
+import { prisma } from "../utils/prisma";
 
 // ---- mapeadores (front -> enums do Prisma)
 const mapTipo = (t: string): AgentType => {
-  const map = {
-    'Secretária': 'SECRETARIA',
-    'SDR': 'SDR',
-    'Pós-venda': 'POS_VENDA',
-    'Suporte Técnico': 'SUPORTE_TECNICO',
-    'Vendedor': 'VENDEDOR',
-    'Financeiro': 'FINANCEIRO',
-    'Logística': 'LOGISTICA',
-    'RH': 'RH',
-  } as const;
-  const res = map[t as keyof typeof map];
-  if (!res) throw new Error(`tipo inválido: ${t}`);
-  return res as AgentType;
+	const map = {
+		Secretária: "SECRETARIA",
+		SDR: "SDR",
+		"Pós-venda": "POS_VENDA",
+		"Suporte Técnico": "SUPORTE_TECNICO",
+		Vendedor: "VENDEDOR",
+		Financeiro: "FINANCEIRO",
+		Logística: "LOGISTICA",
+		RH: "RH",
+	} as const;
+	const res = map[t as keyof typeof map];
+	if (!res) throw new Error(`tipo inválido: ${t}`);
+	return res as AgentType;
 };
 
 const mapStatus = (s?: string): AgentStatus =>
-  s === 'PAUSADO' ? 'PAUSADO' : s === 'RASCUNHO' ? 'RASCUNHO' : 'ATIVO';
+	s === "PAUSADO" ? "PAUSADO" : s === "RASCUNHO" ? "RASCUNHO" : "ATIVO";
 
 // se seus canais existem como enum Channel no Prisma, use as strings do enum do BD:
 const mapChannel = (c: string) => {
-  const map = {
-    WhatsApp: 'WHATSAPP',
-    Web: 'WEB',
-    Instagram: 'INSTAGRAM',
-    Telefone: 'TELEFONE',
-    Email: 'EMAIL',
-    Telegram: 'TELEGRAM',
-    Facebook: 'FACEBOOK',
-  } as const;
-  const res = map[c as keyof typeof map];
-  if (!res) throw new Error(`canal inválido: ${c}`);
-  return res; // string do enum do BD
+	const map = {
+		WhatsApp: "WHATSAPP",
+		Web: "WEB",
+		Instagram: "INSTAGRAM",
+		Telefone: "TELEFONE",
+		Email: "EMAIL",
+		Telegram: "TELEGRAM",
+		Facebook: "FACEBOOK",
+	} as const;
+	const res = map[c as keyof typeof map];
+	if (!res) throw new Error(`canal inválido: ${c}`);
+	return res; // string do enum do BD
 };
 
 // ---- mapeadores (BD -> rótulos da UI) para o GET
 const tipoToLabel = (t: AgentType | string) => {
-  switch (String(t)) {
-    case 'SECRETARIA': return 'Secretária';
-    case 'SDR': return 'SDR';
-    case 'POS_VENDA': return 'Pós-venda';
-    case 'SUPORTE_TECNICO': return 'Suporte Técnico';
-    case 'VENDEDOR': return 'Vendedor';
-    case 'FINANCEIRO': return 'Financeiro';
-    case 'LOGISTICA': return 'Logística';
-    case 'RH': return 'RH';
-    default: return 'SDR';
-  }
+	switch (String(t)) {
+		case "SECRETARIA":
+			return "Secretária";
+		case "SDR":
+			return "SDR";
+		case "POS_VENDA":
+			return "Pós-venda";
+		case "SUPORTE_TECNICO":
+			return "Suporte Técnico";
+		case "VENDEDOR":
+			return "Vendedor";
+		case "FINANCEIRO":
+			return "Financeiro";
+		case "LOGISTICA":
+			return "Logística";
+		case "RH":
+			return "RH";
+		default:
+			return "SDR";
+	}
 };
 const channelToLabel = (c: string) => {
-  switch (String(c)) {
-    case 'WHATSAPP': return 'WhatsApp';
-    case 'WEB': return 'Web';
-    case 'INSTAGRAM': return 'Instagram';
-    case 'TELEFONE': return 'Telefone';
-    case 'EMAIL': return 'Email';
-    case 'TELEGRAM': return 'Telegram';
-    case 'FACEBOOK': return 'Facebook';
-    default: return c;
-  }
+	switch (String(c)) {
+		case "WHATSAPP":
+			return "WhatsApp";
+		case "WEB":
+			return "Web";
+		case "INSTAGRAM":
+			return "Instagram";
+		case "TELEFONE":
+			return "Telefone";
+		case "EMAIL":
+			return "Email";
+		case "TELEGRAM":
+			return "Telegram";
+		case "FACEBOOK":
+			return "Facebook";
+		default:
+			return c;
+	}
 };
 
 // ---- validação do payload
 const AgentCreatePayload = z.object({
-  nome: z.string().min(1),
-  tipo: z.string(),
-  status: z.string().optional(),
-  parentId: z.string().optional().nullable(),
-  persona: z.string().optional().nullable(),
-  herdaPersonaDoPai: z.boolean().optional(),
-  canais: z.array(z.string()).optional(), // ["WhatsApp", ...]
-  userId: z.string().optional(),          // só como fallback; prefira header/sessão
+	nome: z.string().min(1),
+	tipo: z.string(),
+	status: z.string().optional(),
+	parentId: z.string().optional().nullable(),
+	persona: z.string().optional().nullable(),
+	herdaPersonaDoPai: z.boolean().optional(),
+	canais: z.array(z.string()).optional(), // ["WhatsApp", ...]
+	userId: z.string().optional(), // só como fallback; prefira header/sessão
 });
 
 export const agentEndpoints: CustomEndpointDefinition[] = [
-  // ===== GET /api/agents (lista) =====
-  {
-    path: '/api/agents',
-    method: 'get' as const,
-    handler: async (c: any) => {
-      const userId = c.req.header('x-user-id'); // opcional: filtra por dono
-      const where = userId ? { ownerId: userId } : undefined;
+	// ===== GET /api/agents (lista) =====
+	{
+		path: "/api/agents",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id"); // opcional: filtra por dono
+			const where = userId ? { ownerId: userId } : undefined;
 
-      const rows = await prisma.agent.findMany({
-        where,
-        include: { canais: true },
-        orderBy: { createdAt: 'asc' },
-      });
+			const rows = await prisma.agent.findMany({
+				where,
+				include: { canais: true },
+				orderBy: { createdAt: "asc" },
+			});
 
-      const data = rows.map((a) => ({
-        id: a.id,
-        nome: a.nome,
-        tipo: tipoToLabel(a.tipo),            // enum BD -> rótulo da UI
-        status: a.status,                     // 'ATIVO' | 'PAUSADO' | 'RASCUNHO'
-        parentId: a.parentId,
-        persona: a.persona ?? undefined,
-        herdaPersonaDoPai: !!a.herdaPersonaDoPai,
-        canais: a.canais.map((c) => channelToLabel(c.channel)),
-      }));
+			const data = rows.map((a) => ({
+				id: a.id,
+				nome: a.nome,
+				tipo: tipoToLabel(a.tipo), // enum BD -> rótulo da UI
+				status: a.status, // 'ATIVO' | 'PAUSADO' | 'RASCUNHO'
+				parentId: a.parentId,
+				persona: a.persona ?? undefined,
+				herdaPersonaDoPai: !!a.herdaPersonaDoPai,
+				canais: a.canais.map((c) => channelToLabel(c.channel)),
+			}));
 
-      return c.json(data);
-    },
-    description: '[privada] lista agentes',
-  },
+			return c.json(data);
+		},
+		description: "[privada] lista agentes",
+	},
 
-  // ===== POST /api/agents (cria) =====
-  {
-    path: '/api/agents',
-    method: 'post' as const,
-    handler: async (c: any) => {
-      const body = await c.req.json();
-      const parsed = AgentCreatePayload.safeParse(body);
-      if (!parsed.success) {
-        return c.json({ success: false, message: parsed.error.message }, 400);
-      }
-      const p = parsed.data;
+	// ===== POST /api/agents (cria) =====
+	{
+		path: "/api/agents",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const body = await c.req.json();
+			const parsed = AgentCreatePayload.safeParse(body);
+			if (!parsed.success) {
+				return c.json({ success: false, message: parsed.error.message }, 400);
+			}
+			const p = parsed.data;
 
-      // ⚠️ obtenha userId de forma segura (sessão/token). Aqui leio do header:
-      const userId = c.req.header('x-user-id') ?? p.userId;
-      if (!userId) return c.json({ success: false, message: 'missing userId' }, 401);
+			// ⚠️ obtenha userId de forma segura (sessão/token). Aqui leio do header:
+			const userId = c.req.header("x-user-id") ?? p.userId;
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      // valida parent, se enviado
-      if (p.parentId) {
-        const parent = await prisma.agent.findUnique({ where: { id: p.parentId } });
-        if (!parent) return c.json({ success: false, message: 'parentId inválido' }, 400);
-      }
+			// valida parent, se enviado
+			if (p.parentId) {
+				const parent = await prisma.agent.findUnique({
+					where: { id: p.parentId },
+				});
+				if (!parent)
+					return c.json({ success: false, message: "parentId inválido" }, 400);
+			}
 
-      // mapeia enums
-      let tipoEnum: AgentType;
-      let statusEnum: AgentStatus;
-      try {
-        tipoEnum = mapTipo(p.tipo);
-        statusEnum = mapStatus(p.status);
-      } catch (e: any) {
-        return c.json({ success: false, message: e.message }, 400);
-      }
+			// mapeia enums
+			let tipoEnum: AgentType;
+			let statusEnum: AgentStatus;
+			try {
+				tipoEnum = mapTipo(p.tipo);
+				statusEnum = mapStatus(p.status);
+			} catch (e: unknown) {
+				const message = e instanceof Error ? e.message : "Unknown error";
+				return c.json({ success: false, message }, 400);
+			}
 
-      // 1) cria o agente (usar ownerId direto evita conflito de variantes no create)
-      const created = await prisma.agent.create({
-        data: {
-          nome: p.nome,
-          tipo: tipoEnum,
-          status: statusEnum,
-          parentId: p.parentId ?? null,
-          persona: p.persona ?? null,
-          herdaPersonaDoPai: !!p.herdaPersonaDoPai,
-          ownerId: userId,
-        },
-      });
+			// 1) cria o agente (usar ownerId direto evita conflito de variantes no create)
+			const created = await prisma.agent.create({
+				data: {
+					nome: p.nome,
+					tipo: tipoEnum,
+					status: statusEnum,
+					parentId: p.parentId ?? null,
+					persona: p.persona ?? null,
+					herdaPersonaDoPai: !!p.herdaPersonaDoPai,
+					ownerId: userId,
+				},
+			});
 
-      // 2) cria canais à parte
-      if (p.canais?.length) {
-        await prisma.agentChannel.createMany({
-          data: p.canais.map((label) => ({
-            agentId: created.id,
-            channel: mapChannel(label),
-          })),
-          skipDuplicates: true,
-        });
-      }
+			// 2) cria canais à parte
+			if (p.canais?.length) {
+				await prisma.agentChannel.createMany({
+					data: p.canais.map((label) => ({
+						agentId: created.id,
+						channel: mapChannel(label),
+					})),
+					skipDuplicates: true,
+				});
+			}
 
-      return c.json({ success: true, data: created }, 201);
-    },
-    description: '[privada] cria agente',
-  },
+			return c.json({ success: true, data: created }, 201);
+		},
+		description: "[privada] cria agente",
+	},
 ];

--- a/src/endpoints/documents.ts
+++ b/src/endpoints/documents.ts
@@ -1,162 +1,181 @@
+import type { CustomEndpointDefinition } from "@voltagent/core";
 // api/documents.endpoints.ts
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
+import {
+	DocumentCreatePayload,
+	DocumentUpdatePayload,
+	kindFromLabel,
+	kindToLabel,
+} from "../utils/documents.helpers";
 import { prisma } from "../utils/prisma";
-import { kindFromLabel, kindToLabel, DocumentCreatePayload, DocumentUpdatePayload } from "../utils/documents.helpers";
 
 export const documentEndpoints: CustomEndpointDefinition[] = [
-  // LIST
-  {
-    path: "/api/documents",
-    method: "get" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// LIST
+	{
+		path: "/api/documents",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const kindLabel = c.req.query("kind"); // ?kind=script|csv|media|rule|other
-      const where: any = { ownerId: userId };
-      if (kindLabel) where.kind = kindFromLabel(String(kindLabel));
+			const kindLabel = c.req.query("kind"); // ?kind=script|csv|media|rule|other
+			const where: { ownerId: string; kind?: string } = { ownerId: userId };
+			if (kindLabel) where.kind = kindFromLabel(String(kindLabel));
 
-      const rows = await prisma.document.findMany({
-        where,
-        orderBy: { createdAt: "desc" },
-      });
+			const rows = await prisma.document.findMany({
+				where,
+				orderBy: { createdAt: "desc" },
+			});
 
-      const data = rows.map((d) => ({
-        id: d.id,
-        name: d.name,
-        kind: kindToLabel(d.kind),
-        mimeType: d.mimeType ?? undefined,
-        url: d.url ?? undefined,
-        body: d.body ?? undefined,
-        tags: (d.tags as any) ?? [],
-        status: d.status ?? undefined,
-        perm: d.perm ?? undefined,
-        meta: (d.meta as any) ?? undefined,
-        createdAt: d.createdAt,
-      }));
+			const data = rows.map((d) => ({
+				id: d.id,
+				name: d.name,
+				kind: kindToLabel(d.kind),
+				mimeType: d.mimeType ?? undefined,
+				url: d.url ?? undefined,
+				body: d.body ?? undefined,
+				tags: (d.tags as unknown) ?? [],
+				status: d.status ?? undefined,
+				perm: d.perm ?? undefined,
+				meta: (d.meta as unknown) ?? undefined,
+				createdAt: d.createdAt,
+			}));
 
-      return c.json(data);
-    },
-    description: "[privada] lista documentos do usuário (filtrável por kind)",
-  },
+			return c.json(data);
+		},
+		description: "[privada] lista documentos do usuário (filtrável por kind)",
+	},
 
-  // CREATE
-  {
-    path: "/api/documents",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// CREATE
+	{
+		path: "/api/documents",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const body = await c.req.json();
-      const parsed = DocumentCreatePayload.safeParse(body);
-      if (!parsed.success) return c.json({ success: false, message: parsed.error.message }, 400);
-      const p = parsed.data;
+			const body = await c.req.json();
+			const parsed = DocumentCreatePayload.safeParse(body);
+			if (!parsed.success)
+				return c.json({ success: false, message: parsed.error.message }, 400);
+			const p = parsed.data;
 
-      const created = await prisma.document.create({
-        data: {
-          ownerId: userId,
-          name: p.name,
-          kind: kindFromLabel(p.kind),
-          mimeType: p.mimeType,
-          url: p.url,
-          body: p.body,
-          tags: p.tags as any,
-          status: p.status,
-          perm: p.perm,
-          meta: p.meta as any,
-        },
-      });
+			const created = await prisma.document.create({
+				data: {
+					ownerId: userId,
+					name: p.name,
+					kind: kindFromLabel(p.kind),
+					mimeType: p.mimeType,
+					url: p.url,
+					body: p.body,
+					tags: p.tags as unknown,
+					status: p.status,
+					perm: p.perm,
+					meta: p.meta as unknown,
+				},
+			});
 
-      return c.json({ success: true, data: { id: created.id } }, 201);
-    },
-    description: "[privada] cria documento (script/csv/media/rule)",
-  },
+			return c.json({ success: true, data: { id: created.id } }, 201);
+		},
+		description: "[privada] cria documento (script/csv/media/rule)",
+	},
 
-  // GET BY ID
-  {
-    path: "/api/documents/:id",
-    method: "get" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// GET BY ID
+	{
+		path: "/api/documents/:id",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const id = c.req.param("id");
-      const d = await prisma.document.findFirst({ where: { id, ownerId: userId } });
-      if (!d) return c.json({ success: false, message: "not found" }, 404);
+			const id = c.req.param("id");
+			const d = await prisma.document.findFirst({
+				where: { id, ownerId: userId },
+			});
+			if (!d) return c.json({ success: false, message: "not found" }, 404);
 
-      return c.json({
-        id: d.id,
-        name: d.name,
-        kind: kindToLabel(d.kind),
-        mimeType: d.mimeType ?? undefined,
-        url: d.url ?? undefined,
-        body: d.body ?? undefined,
-        tags: (d.tags as any) ?? [],
-        status: d.status ?? undefined,
-        perm: d.perm ?? undefined,
-        meta: (d.meta as any) ?? undefined,
-        createdAt: d.createdAt,
-      });
-    },
-    description: "[privada] obtém documento",
-  },
+			return c.json({
+				id: d.id,
+				name: d.name,
+				kind: kindToLabel(d.kind),
+				mimeType: d.mimeType ?? undefined,
+				url: d.url ?? undefined,
+				body: d.body ?? undefined,
+				tags: (d.tags as unknown) ?? [],
+				status: d.status ?? undefined,
+				perm: d.perm ?? undefined,
+				meta: (d.meta as unknown) ?? undefined,
+				createdAt: d.createdAt,
+			});
+		},
+		description: "[privada] obtém documento",
+	},
 
-  // UPDATE
-  {
-    path: "/api/documents/:id",
-    method: "put" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// UPDATE
+	{
+		path: "/api/documents/:id",
+		method: "put" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const id = c.req.param("id");
-      const body = await c.req.json();
-      const parsed = DocumentUpdatePayload.safeParse(body);
-      if (!parsed.success) return c.json({ success: false, message: parsed.error.message }, 400);
-      const p = parsed.data;
+			const id = c.req.param("id");
+			const body = await c.req.json();
+			const parsed = DocumentUpdatePayload.safeParse(body);
+			if (!parsed.success)
+				return c.json({ success: false, message: parsed.error.message }, 400);
+			const p = parsed.data;
 
-      const exists = await prisma.document.findFirst({ where: { id, ownerId: userId } });
-      if (!exists) return c.json({ success: false, message: "not found" }, 404);
+			const exists = await prisma.document.findFirst({
+				where: { id, ownerId: userId },
+			});
+			if (!exists) return c.json({ success: false, message: "not found" }, 404);
 
-      const updated = await prisma.document.update({
-        where: { id },
-        data: {
-          ...(p.name ? { name: p.name } : {}),
-          ...(p.kind ? { kind: kindFromLabel(p.kind) } : {}),
-          ...(p.mimeType ? { mimeType: p.mimeType } : {}),
-          ...(p.url ? { url: p.url } : {}),
-          ...(p.body !== undefined ? { body: p.body } : {}),
-          ...(p.tags ? { tags: p.tags as any } : {}),
-          ...(p.status ? { status: p.status } : {}),
-          ...(p.perm ? { perm: p.perm } : {}),
-          ...(p.meta ? { meta: p.meta as any } : {}),
-        },
-      });
+			const updated = await prisma.document.update({
+				where: { id },
+				data: {
+					...(p.name ? { name: p.name } : {}),
+					...(p.kind ? { kind: kindFromLabel(p.kind) } : {}),
+					...(p.mimeType ? { mimeType: p.mimeType } : {}),
+					...(p.url ? { url: p.url } : {}),
+					...(p.body !== undefined ? { body: p.body } : {}),
+					...(p.tags ? { tags: p.tags as unknown } : {}),
+					...(p.status ? { status: p.status } : {}),
+					...(p.perm ? { perm: p.perm } : {}),
+					...(p.meta ? { meta: p.meta as unknown } : {}),
+				},
+			});
 
-      return c.json({ success: true, data: { id: updated.id } });
-    },
-    description: "[privada] atualiza documento",
-  },
+			return c.json({ success: true, data: { id: updated.id } });
+		},
+		description: "[privada] atualiza documento",
+	},
 
-  // DELETE
-  {
-    path: "/api/documents/:id",
-    method: "delete" as const,
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId) return c.json({ success: false, message: "missing userId" }, 401);
+	// DELETE
+	{
+		path: "/api/documents/:id",
+		method: "delete" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const id = c.req.param("id");
-      // segurança: só do owner
-      const exists = await prisma.document.findFirst({ where: { id, ownerId: userId } });
-      if (!exists) return c.json({ success: false, message: "not found" }, 404);
+			const id = c.req.param("id");
+			// segurança: só do owner
+			const exists = await prisma.document.findFirst({
+				where: { id, ownerId: userId },
+			});
+			if (!exists) return c.json({ success: false, message: "not found" }, 404);
 
-      await prisma.agentDocument.deleteMany({ where: { documentId: id } }); // desliga vínculos
-      await prisma.document.delete({ where: { id } });
+			await prisma.agentDocument.deleteMany({ where: { documentId: id } }); // desliga vínculos
+			await prisma.document.delete({ where: { id } });
 
-      return c.json({ success: true });
-    },
-    description: "[privada] apaga documento (remove vínculos antes)",
-  },
+			return c.json({ success: true });
+		},
+		description: "[privada] apaga documento (remove vínculos antes)",
+	},
 ];

--- a/src/endpoints/files.ts
+++ b/src/endpoints/files.ts
@@ -1,66 +1,76 @@
-// api/files.endpoints.ts
-import { CustomEndpointDefinition } from "@voltagent/core";
 import fs from "node:fs";
 import path from "node:path";
 import { Readable } from "node:stream";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+// api/files.endpoints.ts
+import type { Context } from "hono";
 import { prisma } from "../utils/prisma";
 
 export const fileEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/files/:id",
-    method: "get" as const,
-    description: "[privada] serve o arquivo do documento por ID (streaming)",
-    handler: async (c: any) => {
-      const userId = (c.req.header("x-user-id") || "").trim();
-      if (!userId)
-        return c.json({ success: false, message: "missing userId" }, 401);
+	{
+		path: "/api/files/:id",
+		method: "get" as const,
+		description: "[privada] serve o arquivo do documento por ID (streaming)",
+		handler: async (c: Context): Promise<Response> => {
+			const userId = (c.req.header("x-user-id") || "").trim();
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const id = c.req.param("id");
-      console.log("[FILES] userId=", JSON.stringify(c.req.header("x-user-id")), "id=", c.req.param("id"));
+			const id = c.req.param("id");
+			console.log(
+				"[FILES] userId=",
+				JSON.stringify(c.req.header("x-user-id")),
+				"id=",
+				c.req.param("id"),
+			);
 
-      // 1) Busque pelo id primeiro
-      const d = await prisma.document.findUnique({ where: { id } });
-      if (!d) {
-        return c.json({ success:false, message:"not found (doc)", id, userId }, 404);
+			// 1) Busque pelo id primeiro
+			const d = await prisma.document.findUnique({ where: { id } });
+			if (!d) {
+				return c.json(
+					{ success: false, message: "not found (doc)", id, userId },
+					404,
+				);
 
-        // doc realmente não existe
-      }
+				// doc realmente não existe
+			}
 
-      // 2) Verifique ownership separado para erro mais claro
-      if (d.ownerId !== userId) {
-        return c.json(
-          { success: false, message: "forbidden (owner mismatch)" },
-          403
-        );
-      }
+			// 2) Verifique ownership separado para erro mais claro
+			if (d.ownerId !== userId) {
+				return c.json(
+					{ success: false, message: "forbidden (owner mismatch)" },
+					403,
+				);
+			}
 
-      // 3) Caminho físico
-      const meta = (d.meta as any) || {};
-      let p: string | undefined = meta.path;
-      if (!p)
-        return c.json({ success: false, message: "file path missing" }, 500);
+			// 3) Caminho físico
+			const meta = (d.meta as Record<string, unknown>) || {};
+			let p: string | undefined = meta.path as string | undefined;
+			if (!p)
+				return c.json({ success: false, message: "file path missing" }, 500);
 
-      p = path.normalize(p);
+			p = path.normalize(p);
 
-      if (!fs.existsSync(p)) {
-        return c.json(
-          { success: false, message: "file not found on disk", path: p },
-          410
-        );
-      }
+			if (!fs.existsSync(p)) {
+				return c.json(
+					{ success: false, message: "file not found on disk", path: p },
+					410,
+				);
+			}
 
-      const fileStream = fs.createReadStream(p);
-      const webStream = Readable.toWeb(fileStream) as any;
+			const fileStream = fs.createReadStream(p);
+			const webStream = Readable.toWeb(
+				fileStream,
+			) as unknown as ReadableStream<Uint8Array>;
 
-      const mime = d.mimeType || "application/octet-stream";
-      const isDownload = c.req.query("download") === "1";
-      const headers: Record<string, string> = { "Content-Type": mime };
-      if (isDownload)
-        headers[
-          "Content-Disposition"
-        ] = `attachment; filename="${encodeURIComponent(d.name)}"`;
+			const mime = d.mimeType || "application/octet-stream";
+			const isDownload = c.req.query("download") === "1";
+			const headers: Record<string, string> = { "Content-Type": mime };
+			if (isDownload)
+				headers["Content-Disposition"] =
+					`attachment; filename="${encodeURIComponent(d.name)}"`;
 
-      return new Response(webStream, { headers, status: 200 });
-    },
-  },
+			return new Response(webStream, { headers, status: 200 });
+		},
+	},
 ];

--- a/src/endpoints/financeiro.ts
+++ b/src/endpoints/financeiro.ts
@@ -1,14 +1,12 @@
 import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { FinanceiroChat } from "../agents/financeiro";
 
 export const financeiroEndpoints: CustomEndpointDefinition[] = [
 	{
 		path: "/api/financeiro/chat",
 		method: "post" as const,
-		handler: async (
-			// biome-ignore lint/suspicious/noExplicitAny: framework context is untyped
-			c: any,
-		) => {
+		handler: async (c: Context): Promise<Response> => {
 			const body = await c.req.json();
 			const { input, userId, conversationId } = body;
 
@@ -22,14 +20,12 @@ export const financeiroEndpoints: CustomEndpointDefinition[] = [
 					},
 					201,
 				);
-			} catch (
-				// biome-ignore lint/suspicious/noExplicitAny: unknown error shape
-				error: any
-			) {
+			} catch (error: unknown) {
 				return c.json(
 					{
 						success: false,
-						message: error.message || "Invalid request body",
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
 						data: null,
 					},
 					400,

--- a/src/endpoints/logistica.ts
+++ b/src/endpoints/logistica.ts
@@ -1,14 +1,12 @@
 import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { LogisticaChat } from "../agents/logistica";
 
 export const logisticaEndpoints: CustomEndpointDefinition[] = [
 	{
 		path: "/api/logistica/chat",
 		method: "post" as const,
-		handler: async (
-			// biome-ignore lint/suspicious/noExplicitAny: framework context is untyped
-			c: any,
-		) => {
+		handler: async (c: Context): Promise<Response> => {
 			const body = await c.req.json();
 			const { input, userId, conversationId } = body;
 
@@ -22,14 +20,12 @@ export const logisticaEndpoints: CustomEndpointDefinition[] = [
 					},
 					201,
 				);
-			} catch (
-				// biome-ignore lint/suspicious/noExplicitAny: unknown error shape
-				error: any
-			) {
+			} catch (error: unknown) {
 				return c.json(
 					{
 						success: false,
-						message: error.message || "Invalid request body",
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
 						data: null,
 					},
 					400,

--- a/src/endpoints/sdr.ts
+++ b/src/endpoints/sdr.ts
@@ -1,38 +1,38 @@
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { SDRChat } from "../agents/sdr";
 
 export const srdEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/sdr",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const body = await c.req.json();
-      const { input, userId, conversationId } = body;
+	{
+		path: "/api/sdr",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const body = await c.req.json();
+			const { input, userId, conversationId } = body;
 
-
-      // pegue os dados do a
-      try {
-   
-       const response =  await SDRChat(input, userId, conversationId)
-        return c.json(
-          {
-            success: true,
-            message: "Login successful",
-            data: response,
-          },
-          201
-        );
-      } catch (error: any) {
-        return c.json(
-          {
-            success: false,
-            message: error.message || "Invalid request body",
-            data: null,
-          },
-          400
-        );
-      }
-    },
-    description: "[publica] busca email para login",
-  }
-]
+			// pegue os dados do a
+			try {
+				const response = await SDRChat(input, userId, conversationId);
+				return c.json(
+					{
+						success: true,
+						message: "Login successful",
+						data: response,
+					},
+					201,
+				);
+			} catch (error: unknown) {
+				return c.json(
+					{
+						success: false,
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
+						data: null,
+					},
+					400,
+				);
+			}
+		},
+		description: "[publica] busca email para login",
+	},
+];

--- a/src/endpoints/secretary.ts
+++ b/src/endpoints/secretary.ts
@@ -1,39 +1,37 @@
-import { CustomEndpointDefinition } from "@voltagent/core";
-import { SDRChat } from "../agents/sdr";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { SecretaryChat } from "../agents/secretary";
 
 export const secretaryEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/secretary/chat",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const body = await c.req.json();
-      const { input, userId, conversationId } = body;
+	{
+		path: "/api/secretary/chat",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const body = await c.req.json();
+			const { input, userId, conversationId } = body;
 
-
-      try {
-    
-       const response =  await SecretaryChat(input, userId, conversationId)
-        return c.json(
-          {
-            success: true,
-            message: "message successfull",
-            data: response,
-          },
-          201
-        );
-      } catch (error: any) {
-        return c.json(
-          {
-            success: false,
-            message: error.message || "Invalid request body",
-            data: null,
-          },
-          400
-        );
-      }
-    },
-    description: "[publica] chat com secretária",
-  },
-]
-
+			try {
+				const response = await SecretaryChat(input, userId, conversationId);
+				return c.json(
+					{
+						success: true,
+						message: "message successfull",
+						data: response,
+					},
+					201,
+				);
+			} catch (error: unknown) {
+				return c.json(
+					{
+						success: false,
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
+						data: null,
+					},
+					400,
+				);
+			}
+		},
+		description: "[publica] chat com secretária",
+	},
+];

--- a/src/endpoints/supervisor.ts
+++ b/src/endpoints/supervisor.ts
@@ -1,48 +1,49 @@
 // api/supervisor.endpoints.ts
 
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { prisma } from "../utils/prisma";
 
 export const supervisorEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: '/api/supervisor',
-    method: 'get' as const,
-    handler: async (c: any) => {
-      const s = await prisma.supervisorConfig.findUnique({ where: { id: 1 } });
-      return c.json({
-        id: String(s?.id ?? 1),
-        nome: s?.nome ?? 'Supervisor',
-        status: s?.online ? 'online' : 'offline',
-        instrucoes: s?.instrucoes ?? '',
-        // opcional: pode enviar também papel/playbook e o front usa direto
-        papel: 'Supervisor Geral',
-        playbook: {
-          slaMin: s?.slaMin ?? 5,
-          fallbackAtivo: s?.fallbackAtivo ?? true,
-          horarios: (s?.horariosJson as any) ?? { dias: [], janelas: [] },
-        },
-      });
-    },
-    description: '[pública] dados do supervisor',
-  },
-  {
-    path: '/api/supervisor',
-    method: 'put' as const,
-    handler: async (c: any) => {
-      const body = await c.req.json();
-      const { instrucoes, playbook } = body;
-      await prisma.supervisorConfig.upsert({
-        where: { id: 1 },
-        update: {
-          instrucoes,
-          slaMin: playbook?.slaMin,
-          fallbackAtivo: playbook?.fallbackAtivo,
-          horariosJson: playbook?.horarios,
-        },
-        create: { id: 1, nome: 'Supervisor', online: false, instrucoes },
-      });
-      return c.json({ ok: true });
-    },
-    description: '[privada] atualiza supervisor',
-  },
+	{
+		path: "/api/supervisor",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const s = await prisma.supervisorConfig.findUnique({ where: { id: 1 } });
+			return c.json({
+				id: String(s?.id ?? 1),
+				nome: s?.nome ?? "Supervisor",
+				status: s?.online ? "online" : "offline",
+				instrucoes: s?.instrucoes ?? "",
+				// opcional: pode enviar também papel/playbook e o front usa direto
+				papel: "Supervisor Geral",
+				playbook: {
+					slaMin: s?.slaMin ?? 5,
+					fallbackAtivo: s?.fallbackAtivo ?? true,
+					horarios: (s?.horariosJson as unknown) ?? { dias: [], janelas: [] },
+				},
+			});
+		},
+		description: "[pública] dados do supervisor",
+	},
+	{
+		path: "/api/supervisor",
+		method: "put" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const body = await c.req.json();
+			const { instrucoes, playbook } = body;
+			await prisma.supervisorConfig.upsert({
+				where: { id: 1 },
+				update: {
+					instrucoes,
+					slaMin: playbook?.slaMin,
+					fallbackAtivo: playbook?.fallbackAtivo,
+					horariosJson: playbook?.horarios,
+				},
+				create: { id: 1, nome: "Supervisor", online: false, instrucoes },
+			});
+			return c.json({ ok: true });
+		},
+		description: "[privada] atualiza supervisor",
+	},
 ];

--- a/src/endpoints/teams.ts
+++ b/src/endpoints/teams.ts
@@ -1,32 +1,42 @@
 // api/teams.endpoints.ts
 
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { prisma } from "../utils/prisma";
 
-
 export const teamEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: '/api/teams',
-    method: 'get' as const,
-    handler: async (c: any) => {
-      const rows = await prisma.team.findMany({
-        include: {
-          membros: { orderBy: { pos: 'asc' }, select: { agentId: true, pos: true } },
-          regras: true,
-        },
-      });
-      const data = rows.map((t) => ({
-        id: t.id,
-        nome: t.nome,
-        ativo: t.ativo,
-        membros: t.membros.map((m) => m.agentId),
-        prioridade: t.membros.sort((a, b) => a.pos - b.pos).map((m) => m.agentId),
-        regras: t.regras.map((r) => ({
-          id: r.id, de: r.deId, para: r.paraId, tipo: r.tipo, condicao: r.condicao, ordem: r.ordem,
-        })),
-      }));
-      return c.json(data);
-    },
-    description: '[privada] lista times',
-  },
+	{
+		path: "/api/teams",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const rows = await prisma.team.findMany({
+				include: {
+					membros: {
+						orderBy: { pos: "asc" },
+						select: { agentId: true, pos: true },
+					},
+					regras: true,
+				},
+			});
+			const data = rows.map((t) => ({
+				id: t.id,
+				nome: t.nome,
+				ativo: t.ativo,
+				membros: t.membros.map((m) => m.agentId),
+				prioridade: t.membros
+					.sort((a, b) => a.pos - b.pos)
+					.map((m) => m.agentId),
+				regras: t.regras.map((r) => ({
+					id: r.id,
+					de: r.deId,
+					para: r.paraId,
+					tipo: r.tipo,
+					condicao: r.condicao,
+					ordem: r.ordem,
+				})),
+			}));
+			return c.json(data);
+		},
+		description: "[privada] lista times",
+	},
 ];

--- a/src/endpoints/upload-files.ts
+++ b/src/endpoints/upload-files.ts
@@ -1,12 +1,13 @@
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import {
-  bufferFromBlob,
-  removeIfExists,
-  sanitizeFilename,
-  saveBufferToVolume,
-  sha256,
-  statSafe,
-  uniqueName,
+	bufferFromBlob,
+	removeIfExists,
+	sanitizeFilename,
+	saveBufferToVolume,
+	sha256,
+	statSafe,
+	uniqueName,
 } from "../utils/files";
 
 // 👇 tipos
@@ -18,128 +19,128 @@ export const prisma = new PrismaClient();
 
 // mapeia mimetype/kind do teu domínio
 function toDocKind(label: string): DocKindT | undefined {
-  switch (label.toUpperCase()) {
-    case "SCRIPT":
-      return DocKind.SCRIPT;
-    case "CSV":
-      return DocKind.CSV;
-    case "MEDIA":
-      return DocKind.MEDIA;
-    case "RULE":
-      return DocKind.RULE;
-    case "OTHER":
-      return DocKind.OTHER;
-    default:
-      return undefined;
-  }
+	switch (label.toUpperCase()) {
+		case "SCRIPT":
+			return DocKind.SCRIPT;
+		case "CSV":
+			return DocKind.CSV;
+		case "MEDIA":
+			return DocKind.MEDIA;
+		case "RULE":
+			return DocKind.RULE;
+		case "OTHER":
+			return DocKind.OTHER;
+		default:
+			return undefined;
+	}
 }
 
 function guessKind(mime: string | null, name: string): DocKindT {
-  const n = name.toLowerCase();
-  if (n.endsWith(".csv")) return DocKind.CSV;
-  if (n.endsWith(".xlsx") || n.endsWith(".xls")) return DocKind.MEDIA; // ajuste se houver enum específico p/ planilha
-  if (n.endsWith(".txt")) return DocKind.OTHER;
-  if (
-    (mime || "").startsWith("audio/") ||
-    (mime || "").startsWith("video/") ||
-    (mime || "").startsWith("image/")
-  )
-    return DocKind.MEDIA;
-  return DocKind.OTHER;
+	const n = name.toLowerCase();
+	if (n.endsWith(".csv")) return DocKind.CSV;
+	if (n.endsWith(".xlsx") || n.endsWith(".xls")) return DocKind.MEDIA; // ajuste se houver enum específico p/ planilha
+	if (n.endsWith(".txt")) return DocKind.OTHER;
+	if (
+		(mime || "").startsWith("audio/") ||
+		(mime || "").startsWith("video/") ||
+		(mime || "").startsWith("image/")
+	)
+		return DocKind.MEDIA;
+	return DocKind.OTHER;
 }
 
 export const uploadDirectEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/uploads/direct",
-    method: "post" as const,
-    description:
-      "[privada] upload multipart para volume docker e criação de document",
-    handler: async (c: any) => {
-      const userId = c.req.header("x-user-id");
-      if (!userId)
-        return c.json({ success: false, message: "missing userId" }, 401);
+	{
+		path: "/api/uploads/direct",
+		method: "post" as const,
+		description:
+			"[privada] upload multipart para volume docker e criação de document",
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const form = await c.req.formData();
-      const file = form.get("file") as File | null;
-      const tags = form.get("tags");
-      const perm = form.get("perm");
-      const status = form.get("status");
-      const kindOverride = form.get("kind"); // string opcional
+			const form = await c.req.formData();
+			const file = form.get("file") as File | null;
+			const tags = form.get("tags");
+			const perm = form.get("perm");
+			const status = form.get("status");
+			const kindOverride = form.get("kind"); // string opcional
 
-      if (!file)
-        return c.json({ success: false, message: "missing file" }, 400);
+			if (!file)
+				return c.json({ success: false, message: "missing file" }, 400);
 
-      const originalName = sanitizeFilename((file as any).name || "upload.bin");
-      const mimeType = (file as any).type || null;
+			const originalName = sanitizeFilename(file.name || "upload.bin");
+			const mimeType = file.type || null;
 
-      const maxBytes = 50 * 1024 * 1024;
-      if ((file as any).size > maxBytes) {
-        return c.json({ success: false, message: "file too large" }, 413);
-      }
+			const maxBytes = 50 * 1024 * 1024;
+			if (file.size > maxBytes) {
+				return c.json({ success: false, message: "file too large" }, 413);
+			}
 
-      const buf = await bufferFromBlob(file);
+			const buf = await bufferFromBlob(file);
 
-      const finalName = uniqueName(originalName);
-      const diskPath = await saveBufferToVolume(buf, finalName);
-      const st = await statSafe(diskPath);
-      const size = st?.size ?? buf.length;
-      const hash = sha256(buf);
+			const finalName = uniqueName(originalName);
+			const diskPath = await saveBufferToVolume(buf, finalName);
+			const st = await statSafe(diskPath);
+			const size = st?.size ?? buf.length;
+			const hash = sha256(buf);
 
-      // 🔒 garante um Prisma.DocKind (sem undefined)
-      const kindEnum: DocKindT =
-        toDocKind(typeof kindOverride === "string" ? kindOverride : "") ??
-        guessKind(mimeType, originalName);
+			// 🔒 garante um Prisma.DocKind (sem undefined)
+			const kindEnum: DocKindT =
+				toDocKind(typeof kindOverride === "string" ? kindOverride : "") ??
+				guessKind(mimeType, originalName);
 
-      try {
-        const created = await prisma.document.create({
-          data: {
-            ownerId: userId,
-            name: originalName,
-            kind: kindEnum, // ✔ agora é Prisma.DocKind
-            mimeType: mimeType ?? undefined,
-            url: undefined,
-            body: undefined,
-            tags: tags
-              ? typeof tags === "string" && tags.trim().startsWith("[")
-                ? JSON.parse(String(tags))
-                : String(tags)
-              : undefined,
-            status: status ? String(status) : undefined,
-            perm: perm ? String(perm) : undefined,
-            meta: {
-              storage: "local",
-              path: diskPath,
-              savedAs: finalName,
-              size,
-              sha256: hash,
-            } as any,
-          },
-        });
+			try {
+				const created = await prisma.document.create({
+					data: {
+						ownerId: userId,
+						name: originalName,
+						kind: kindEnum, // ✔ agora é Prisma.DocKind
+						mimeType: mimeType ?? undefined,
+						url: undefined,
+						body: undefined,
+						tags: tags
+							? typeof tags === "string" && tags.trim().startsWith("[")
+								? JSON.parse(String(tags))
+								: String(tags)
+							: undefined,
+						status: status ? String(status) : undefined,
+						perm: perm ? String(perm) : undefined,
+						meta: {
+							storage: "local",
+							path: diskPath,
+							savedAs: finalName,
+							size,
+							sha256: hash,
+						} as unknown,
+					},
+				});
 
-        const fileUrl = `/api/files/${created.id}`;
-        await prisma.document.update({
-          where: { id: created.id },
-          data: { url: fileUrl },
-        });
+				const fileUrl = `/api/files/${created.id}`;
+				await prisma.document.update({
+					where: { id: created.id },
+					data: { url: fileUrl },
+				});
 
-        return c.json(
-          {
-            success: true,
-            data: {
-              id: created.id,
-              name: originalName,
-              mimeType,
-              size,
-              kind: kindEnum,
-              url: fileUrl,
-            },
-          },
-          201
-        );
-      } catch (err) {
-        await removeIfExists(diskPath);
-        throw err;
-      }
-    },
-  },
+				return c.json(
+					{
+						success: true,
+						data: {
+							id: created.id,
+							name: originalName,
+							mimeType,
+							size,
+							kind: kindEnum,
+							url: fileUrl,
+						},
+					},
+					201,
+				);
+			} catch (err: unknown) {
+				await removeIfExists(diskPath);
+				throw err;
+			}
+		},
+	},
 ];

--- a/src/endpoints/user.ts
+++ b/src/endpoints/user.ts
@@ -1,71 +1,74 @@
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { loginUser } from "../services/login";
 import { createInstance } from "../services/users";
 
 export const userEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/login",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const body = await c.req.json();
-      const { email, password } = body;
+	{
+		path: "/api/login",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const body = await c.req.json();
+			const { email, password } = body;
 
-      try {
-        const user = await loginUser(email, password);
+			try {
+				const user = await loginUser(email, password);
 
-        console.log(`user encontrado: ${user}`);
-        return c.json(
-          {
-            success: true,
-            message: "Login successful",
-            data: user,
-          },
-          201
-        );
-      } catch (error: any) {
-        return c.json(
-          {
-            success: false,
-            message: error.message || "Invalid request body",
-            data: null,
-          },
-          400
-        );
-      }
-    },
-    description: "[publica] busca email para login",
-  },
+				console.log(`user encontrado: ${user}`);
+				return c.json(
+					{
+						success: true,
+						message: "Login successful",
+						data: user,
+					},
+					201,
+				);
+			} catch (error: unknown) {
+				return c.json(
+					{
+						success: false,
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
+						data: null,
+					},
+					400,
+				);
+			}
+		},
+		description: "[publica] busca email para login",
+	},
 
-  {
-    path: "/api/instance",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const body = await c.req.json();
-      const { instance, userId } = body;
+	{
+		path: "/api/instance",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const body = await c.req.json();
+			const { instance, userId } = body;
 
-      try {
-        const createdInstance = await createInstance(instance, userId);
+			try {
+				const createdInstance = await createInstance(instance, userId);
 
-        console.log(`user encontrado: ${instance}`);
-        return c.json(
-          {
-            success: true,
-            message: "instance created successful",
-            data: createdInstance,
-          },
-          201
-        );
-      } catch (error: any) {
-        return c.json(
-          {
-            success: false,
-            message: error.message || "Invalid request body",
-            data: null,
-          },
-          400
-        );
-      }
-    },
-    description: "[publica] cria uma instancia no banco",
-  },
+				console.log(`user encontrado: ${instance}`);
+				return c.json(
+					{
+						success: true,
+						message: "instance created successful",
+						data: createdInstance,
+					},
+					201,
+				);
+			} catch (error: unknown) {
+				return c.json(
+					{
+						success: false,
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
+						data: null,
+					},
+					400,
+				);
+			}
+		},
+		description: "[publica] cria uma instancia no banco",
+	},
 ];

--- a/src/endpoints/whatsapp.ts
+++ b/src/endpoints/whatsapp.ts
@@ -1,77 +1,79 @@
-import { CustomEndpointDefinition } from "@voltagent/core";
+import type { CustomEndpointDefinition } from "@voltagent/core";
+import type { Context } from "hono";
 import { SecretaryChat } from "../agents/secretary";
 import { prisma } from "../utils/prisma";
 
 type ParsedMessage = {
-  remoteJid: string | undefined;
-  message: string;
-  sentAt: Date;
-  messageId: string | undefined;
-  fromMe: boolean | undefined;
-  pushName: string;
-  instance: string | undefined;
+	remoteJid: string | undefined;
+	message: string;
+	sentAt: Date;
+	messageId: string | undefined;
+	fromMe: boolean | undefined;
+	pushName: string;
+	instance: string | undefined;
 };
 
 export const whatsappEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/message-upsert",
-    method: "post" as const,
-    handler: async (c: any) => {
-      const body = await c.req.json();
-      const { parsedMessages } = body as { parsedMessages: ParsedMessage[] };
-      // salvar a mensagem no banco de dados
-      try {
-        const savedMessages = await Promise.all(
-          parsedMessages.map((message) =>
-            prisma.messages.create({
-              data: {
-                remoteJid: message.remoteJid || "numero desconhecido",
-                message: message.message,
-                sendAt: message.sentAt,
-                messageId: message.messageId,
-                fromMe: message.fromMe,
-                pushName: message.pushName,
-                instance: message.instance || "indefinida",
-              },
-            })
-          )
-        );
+	{
+		path: "/api/message-upsert",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const body = await c.req.json();
+			const { parsedMessages } = body as { parsedMessages: ParsedMessage[] };
+			// salvar a mensagem no banco de dados
+			try {
+				const savedMessages = await Promise.all(
+					parsedMessages.map((message) =>
+						prisma.messages.create({
+							data: {
+								remoteJid: message.remoteJid || "numero desconhecido",
+								message: message.message,
+								sendAt: message.sentAt,
+								messageId: message.messageId,
+								fromMe: message.fromMe,
+								pushName: message.pushName,
+								instance: message.instance || "indefinida",
+							},
+						}),
+					),
+				);
 
-        // envie para a secretária as mensagens. o user id é o remote JID e o conversationId é a a concatenação entre a messageId junto do sendAt. Input são as mensagens salvas no savedMessages separadas por ponto.
-        const input = savedMessages.map((m) => m.message).join(". ");
-        const userId = savedMessages[0]!.remoteJid;
-        const conversationId =
-          savedMessages[0]?.messageId && savedMessages[0]?.sendAt
-            ? `${
-                savedMessages[0].messageId
-              }_${savedMessages[0].sendAt.getTime()}`
-            : "default_conversation";
+				// envie para a secretária as mensagens. o user id é o remote JID e o conversationId é a a concatenação entre a messageId junto do sendAt. Input são as mensagens salvas no savedMessages separadas por ponto.
+				const input = savedMessages.map((m) => m.message).join(". ");
+				const userId = savedMessages[0]?.remoteJid;
+				const conversationId =
+					savedMessages[0]?.messageId && savedMessages[0]?.sendAt
+						? `${
+								savedMessages[0].messageId
+							}_${savedMessages[0].sendAt.getTime()}`
+						: "default_conversation";
 
-        if (!userId) {
-          throw new Error("UserId não encontrado nas mensagens salvas");
-        }
-        // Envia para a secretária
-        const response = await SecretaryChat(input, userId, conversationId);
+				if (!userId) {
+					throw new Error("UserId não encontrado nas mensagens salvas");
+				}
+				// Envia para a secretária
+				const response = await SecretaryChat(input, userId, conversationId);
 
-        return c.json(
-          {
-            success: true,
-            message: "message successfull",
-            data: response,
-          },
-          201
-        );
-      } catch (error: any) {
-        return c.json(
-          {
-            success: false,
-            message: error.message || "Invalid request body",
-            data: null,
-          },
-          400
-        );
-      }
-    },
-    description: "[publica] chat com secretária",
-  },
+				return c.json(
+					{
+						success: true,
+						message: "message successfull",
+						data: response,
+					},
+					201,
+				);
+			} catch (error: unknown) {
+				return c.json(
+					{
+						success: false,
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
+						data: null,
+					},
+					400,
+				);
+			}
+		},
+		description: "[publica] chat com secretária",
+	},
 ];


### PR DESCRIPTION
## Summary
- type endpoint handlers with Hono `Context`
- use `unknown` error objects and extract message via `instanceof Error`

## Testing
- `npx biome check src/endpoints`
- `npm run lint` *(fails: src/agents/sdr.ts format, src/vector/qdrant.ts format, src/utils/with-cors.ts noExplicitAny, src/retriever/qdrant-retriever.ts noExplicitAny, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af1e8232488328875dfcf67accc8e1