### PR TITLE
Add default campaign handling for leads

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -804,7 +804,7 @@ model Lead {
   capturedAt     DateTime  @default(now())
   status         LeadStatus @default(NEW)
 
-  campaignId     String
+  campaignId     String   @default("DEFAULT")
   campaign       Campaign   @relation(fields: [campaignId], references: [id])
 
   interactions   Interaction[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,1 +1,27 @@
+import { PrismaClient, Channel } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+        await prisma.campaign.upsert({
+                where: { id: "DEFAULT" },
+                update: {},
+                create: {
+                        id: "DEFAULT",
+                        name: "DEFAULT",
+                        channel: Channel.WEB,
+                        startDate: new Date(),
+                },
+        });
+}
+
+main()
+        .then(async () => {
+                await prisma.$disconnect();
+        })
+        .catch(async (e) => {
+                console.error(e);
+                await prisma.$disconnect();
+                process.exit(1);
+        });
 

--- a/src/tools/sdr/index.ts
+++ b/src/tools/sdr/index.ts
@@ -20,13 +20,18 @@ export const createLeadTool = createTool({
 		name: z.string().describe("nome completo do lead"),
 		email: z.string().email().describe("email de contato"),
 		company: z.string().optional().describe("empresa do lead"),
+		campaignId: z
+			.string()
+			.optional()
+			.describe("identificador da campanha de origem"),
 	}),
 	execute: async (args) => {
+		const campaignId = args.campaignId ?? "DEFAULT";
 		try {
 			// Aqui poderia ser realizada uma chamada ao banco de dados ou API externa
 			const result = `lead criado: ${args.name} <${args.email}>${
 				args.company ? ` (${args.company})` : ""
-			}`;
+			} [${campaignId}]`;
 			return { result };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- default campaignId in Lead model to "DEFAULT"
- seed default campaign in database
- allow lead creation tool to accept optional campaignId

## Testing
- `npm run prisma:generate`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npx prisma validate` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b84977c8328a8e7561270b90ba1