### PR TITLE
feat: model agent templates

### DIFF
--- a/prisma/migrations/20250828120000_agent_templates/migration.sql
+++ b/prisma/migrations/20250828120000_agent_templates/migration.sql
@@ -1,0 +1,7 @@
+-- Alter AgentType enum to keep only relevant variants and add isTemplate column
+CREATE TYPE "AgentType_new" AS ENUM ('SECRETARIA','FINANCEIRO','SDR','LOGISTICA');
+ALTER TABLE "agent" ALTER COLUMN "tipo" TYPE "AgentType_new" USING ("tipo"::text::"AgentType_new");
+DROP TYPE "AgentType";
+ALTER TYPE "AgentType_new" RENAME TO "AgentType";
+
+ALTER TABLE "agent" ADD COLUMN "isTemplate" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,13 +201,9 @@ enum AssessmentType {
 // ################## for me -> techinical#################
 enum AgentType {
   SECRETARIA
-  SDR
-  POS_VENDA
-  SUPORTE_TECNICO
-  VENDEDOR
   FINANCEIRO
+  SDR
   LOGISTICA
-  RH
 }
 
 enum AgentStatus {
@@ -263,6 +259,7 @@ model Agent {
   herdaPersonaDoPai Boolean         @default(false)
   color             String? // ex.: "#22c55e"
   saude             String? // "ok" | "med" | "bad" (texto livre ou trocar por enum se quiser)
+  isTemplate        Boolean         @default(false)
   // Hierarquia (self-relation)
   parentId          String?
   parent            Agent?          @relation("AgentChildren", fields: [parentId], references: [id], onDelete: SetNull)
@@ -789,7 +786,7 @@ model Lead {
   id          String     @id @default(cuid())
   firstName   String?
   lastName    String?
-  email       String
+  email       String?    @unique
   phone       String?
   consent     Boolean    @default(false)
   persona     Persona?
@@ -800,25 +797,8 @@ model Lead {
   capturedAt  DateTime   @default(now())
   status      LeadStatus @default(NEW)
 
-  campaignId String
+  campaignId String   @default("DEFAULT")
   campaign   Campaign @relation(fields: [campaignId], references: [id])
-=======
-  id             String    @id @default(cuid())
-  firstName      String?
-  lastName       String?
-  email          String? @unique
-  phone          String?
-  consent        Boolean   @default(false)
-  persona        Persona?
-  series         String?   // série/turno
-  interest       Interest?
-  utmSource      String?
-  utmCampaign    String?
-  capturedAt     DateTime  @default(now())
-  status         LeadStatus @default(NEW)
-
-  campaignId     String   @default("DEFAULT")
-  campaign       Campaign   @relation(fields: [campaignId], references: [id])
 
   interactions Interaction[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-import { PrismaClient, Channel } from "@prisma/client";
+import { PrismaClient, AgentType, Channel, Role } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
@@ -15,38 +13,88 @@ async function main() {
                         startDate: new Date(),
                 },
         });
-}
 
-main()
-        .then(async () => {
-                await prisma.$disconnect();
-        })
-        .catch(async (e) => {
-                console.error(e);
-                await prisma.$disconnect();
-                process.exit(1);
+        await prisma.sponsor.create({
+                data: {
+                        firstName: "John",
+                        lastName: "Doe",
+                        birth: "1980-01-01",
+                        isMain: true,
+                        email: "john.doe@example.com",
+                        phone: "555-0000",
+                },
         });
 
-const prisma = new PrismaClient();
+        const owner = await prisma.user.upsert({
+                where: { email: "template@system.local" },
+                update: {},
+                create: {
+                        name: "Template Owner",
+                        email: "template@system.local",
+                        passwordHash: "",
+                        role: Role.ADMIN,
+                },
+        });
 
-async function main() {
-	await prisma.sponsor.create({
-		data: {
-			firstName: "John",
-			lastName: "Doe",
-			birth: "1980-01-01",
-			isMain: true,
-			email: "john.doe@example.com",
-			phone: "555-0000",
-		},
-	});
+        await prisma.agent.upsert({
+                where: { id: "template-secretaria" },
+                update: {},
+                create: {
+                        id: "template-secretaria",
+                        nome: "Modelo Secretaria",
+                        tipo: AgentType.SECRETARIA,
+                        persona: "Instruções base da secretária",
+                        herdaPersonaDoPai: false,
+                        ownerId: owner.id,
+                        isTemplate: true,
+                },
+        });
+        await prisma.agent.upsert({
+                where: { id: "template-financeiro" },
+                update: {},
+                create: {
+                        id: "template-financeiro",
+                        nome: "Modelo Financeiro",
+                        tipo: AgentType.FINANCEIRO,
+                        persona: "Instruções base do financeiro",
+                        herdaPersonaDoPai: false,
+                        ownerId: owner.id,
+                        isTemplate: true,
+                },
+        });
+        await prisma.agent.upsert({
+                where: { id: "template-sdr" },
+                update: {},
+                create: {
+                        id: "template-sdr",
+                        nome: "Modelo SDR",
+                        tipo: AgentType.SDR,
+                        persona: "Instruções base do SDR",
+                        herdaPersonaDoPai: false,
+                        ownerId: owner.id,
+                        isTemplate: true,
+                },
+        });
+        await prisma.agent.upsert({
+                where: { id: "template-logistica" },
+                update: {},
+                create: {
+                        id: "template-logistica",
+                        nome: "Modelo Logística",
+                        tipo: AgentType.LOGISTICA,
+                        persona: "Instruções base da logística",
+                        herdaPersonaDoPai: false,
+                        ownerId: owner.id,
+                        isTemplate: true,
+                },
+        });
 }
 
 main()
-	.catch((e) => {
-		console.error(e);
-		process.exit(1);
-	})
-	.finally(async () => {
-		await prisma.$disconnect();
-	});
+        .catch((e) => {
+                console.error(e);
+                process.exit(1);
+        })
+        .finally(async () => {
+                await prisma.$disconnect();
+        });

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -3,38 +3,28 @@ import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { makeQdrantRetriever } from "../retriever/qdrant-retriever";
 
-import { financeiroTool } from "../tools/financeiro";
-import { logisticaTool } from "../tools/logistica";
-import { posVendaTool } from "../tools/pos-venda";
-import { rhTool } from "../tools/rh";
-import { sdrLeadTool } from "../tools/sdr";
-import { registrationStudentsTool } from "../tools/secretary";
-import { suporteTecnicoTool } from "../tools/suporte-tecnico";
-import { vendedorTool } from "../tools/vendedor";
+import type { AgentType } from "@prisma/client";
+import type { Tool } from "@voltagent/core";
+import {
+	financeiroTool,
+	logisticaTool,
+	registrationStudentsTool,
+	sdrLeadTool,
+} from "../tools";
 
 import { prisma } from "../utils/prisma";
 
-function toolsForType(tipo: string) {
-	switch (tipo) {
-		case "SECRETARIA":
-			return [registrationStudentsTool];
-		case "SDR":
-			return [sdrLeadTool];
-		case "POS_VENDA":
-			return [posVendaTool];
-		case "SUPORTE_TECNICO":
-			return [suporteTecnicoTool];
-		case "VENDEDOR":
-			return [vendedorTool];
-		case "FINANCEIRO":
-			return [financeiroTool];
-		case "LOGISTICA":
-			return [logisticaTool];
-		case "RH":
-			return [rhTool];
-		default:
-			return [];
-	}
+// biome-ignore lint/suspicious/noExplicitAny: generic tool mapping
+const TOOLS_BY_TYPE: Record<AgentType, Tool<any, any>[]> = {
+	SECRETARIA: [registrationStudentsTool],
+	FINANCEIRO: [financeiroTool],
+	SDR: [sdrLeadTool],
+	LOGISTICA: [logisticaTool],
+};
+
+// biome-ignore lint/suspicious/noExplicitAny: generic tool mapping
+function toolsForType(tipo: AgentType): Tool<any, any>[] {
+	return TOOLS_BY_TYPE[tipo] ?? [];
 }
 
 async function buildInstructions(agentId: string) {

--- a/src/endpoints/agents.ts
+++ b/src/endpoints/agents.ts
@@ -8,13 +8,9 @@ import { prisma } from "../utils/prisma";
 const mapTipo = (t: string): AgentType => {
 	const map = {
 		Secretária: "SECRETARIA",
-		SDR: "SDR",
-		"Pós-venda": "POS_VENDA",
-		"Suporte Técnico": "SUPORTE_TECNICO",
-		Vendedor: "VENDEDOR",
 		Financeiro: "FINANCEIRO",
+		SDR: "SDR",
 		Logística: "LOGISTICA",
-		RH: "RH",
 	} as const;
 	const res = map[t as keyof typeof map];
 	if (!res) throw new Error(`tipo inválido: ${t}`);
@@ -45,20 +41,12 @@ const tipoToLabel = (t: AgentType | string) => {
 	switch (String(t)) {
 		case "SECRETARIA":
 			return "Secretária";
-		case "SDR":
-			return "SDR";
-		case "POS_VENDA":
-			return "Pós-venda";
-		case "SUPORTE_TECNICO":
-			return "Suporte Técnico";
-		case "VENDEDOR":
-			return "Vendedor";
 		case "FINANCEIRO":
 			return "Financeiro";
+		case "SDR":
+			return "SDR";
 		case "LOGISTICA":
 			return "Logística";
-		case "RH":
-			return "RH";
 		default:
 			return "SDR";
 	}

--- a/src/tools/sdr/index.ts
+++ b/src/tools/sdr/index.ts
@@ -29,9 +29,6 @@ export const createLeadTool = createTool({
 		const campaignId = args.campaignId ?? "DEFAULT";
 		try {
 			// Aqui poderia ser realizada uma chamada ao banco de dados ou API externa
-			const result = `lead criado: ${args.name}${
-				args.email ? ` <${args.email}>` : ""
-			}${args.company ? ` (${args.company})` : ""}`;
 			const result = `lead criado: ${args.name} <${args.email}>${
 				args.company ? ` (${args.company})` : ""
 			} [${campaignId}]`;


### PR DESCRIPTION
## Summary
- restrict `AgentType` to four core variants and add `isTemplate`
- seed default template agents for secretaria, financeiro, SDR and logística
- map allowed tools per agent type and simplify endpoint mappings

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af5305267483289557d45ac8c92433