### PR TITLE
feat: expand agent API

### DIFF
--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -15,7 +15,7 @@ import {
 import { prisma } from "../utils/prisma";
 
 // biome-ignore lint/suspicious/noExplicitAny: generic tool mapping
-const TOOLS_BY_TYPE: Record<AgentType, Tool<any, any>[]> = {
+const TOOLS_BY_TYPE: Partial<Record<AgentType, Tool<any, any>[]>> = {
 	SECRETARIA: [registrationStudentsTool],
 	FINANCEIRO: [financeiroTool],
 	SDR: [sdrLeadTool],


### PR DESCRIPTION
## Summary
- add update, status patch, delete, duplicate and chat endpoints for agents
- support linking and unlinking documents via unified /api/agent-documents
- fix tool mapping for optional agent types

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af56116bd08328b924333da2a7d5f6