### PR TITLE
feat: add qdrant training and retriever

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { FinanceiroAgent } from "./agents/financeiro";
 import { LogisticaAgent } from "./agents/logistica";
 import { SDRAgent } from "./agents/sdr";
 import { SecretaryAgent } from "./agents/secretary";
+import { agentTrainEndpoints } from "./endpoints/agent-trainning";
 import { agentEndpoints } from "./endpoints/agents";
 import { agentDocumentEndpoints } from "./endpoints/agents-docs";
 import { documentEndpoints } from "./endpoints/documents";
@@ -41,6 +42,7 @@ registerCustomEndpoints(documentEndpoints);
 registerCustomEndpoints(agentDocumentEndpoints);
 registerCustomEndpoints(uploadDirectEndpoints);
 registerCustomEndpoints(fileEndpoints);
+registerCustomEndpoints(agentTrainEndpoints);
 
 new VoltAgent({
 	agents: {

--- a/src/vector/qdrant.ts
+++ b/src/vector/qdrant.ts
@@ -13,13 +13,23 @@ export const qdrant = new QdrantClient({
 	apiKey: process.env.QDRANT_API_KEY || undefined,
 });
 
-export async function ensureCollection() {
-	const size = process.env.EMBED_MODEL?.includes("large") ? 3072 : 1536;
+export async function ensureCollection(dim = 1536) {
 	try {
 		await qdrant.getCollection(QDRANT_COLLECTION);
 	} catch {
 		await qdrant.createCollection(QDRANT_COLLECTION, {
-			vectors: { size, distance: "Cosine" },
+			vectors: { size: dim, distance: "Cosine" },
 		});
+	}
+
+	for (const field of ["agentId", "documentId"]) {
+		try {
+			await qdrant.createPayloadIndex(QDRANT_COLLECTION, {
+				field_name: field,
+				field_schema: "keyword",
+			});
+		} catch {
+			/* empty */
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- ensure Qdrant collection with payload indexes for agent and document
- upsert embeddings per chunk with agent/document IDs and metadata
- wire training endpoints into API

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af611677a88328b6056c023826f0ca