### PR TITLE
chore: trim OpenAI key and centralize client

### DIFF
--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,7 +1,7 @@
-import { openai } from "@ai-sdk/openai";
 import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { makeQdrantRetriever } from "../retriever/qdrant-retriever";
+import { openai } from "../utils/openai";
 
 import type { AgentType } from "@prisma/client";
 import type { Tool } from "@voltagent/core";

--- a/src/agents/financeiro.ts
+++ b/src/agents/financeiro.ts
@@ -1,8 +1,8 @@
-import { openai } from "@ai-sdk/openai";
 import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { FinanceiroScript } from "../scripts/financeiro-script";
 import { scriptGeral } from "../scripts/geral";
+import { openai } from "../utils/openai";
 
 export const FinanceiroAgent = new Agent({
 	name: "Fiona",

--- a/src/agents/logistica.ts
+++ b/src/agents/logistica.ts
@@ -1,8 +1,8 @@
-import { openai } from "@ai-sdk/openai";
 import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { scriptGeral } from "../scripts/geral";
 import { LogisticaScript } from "../scripts/logistica-script";
+import { openai } from "../utils/openai";
 
 export const LogisticaAgent = new Agent({
 	name: "Leo",

--- a/src/agents/sdr.ts
+++ b/src/agents/sdr.ts
@@ -1,8 +1,8 @@
-import { openai } from "@ai-sdk/openai";
 import { Agent, InMemoryStorage } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { scriptGeral } from "../scripts/geral";
 import { SRDScript } from "../scripts/sdr-script";
+import { openai } from "../utils/openai";
 
 export const SDRAgent = new Agent({
 	name: "SOFIA",

--- a/src/agents/secretary.ts
+++ b/src/agents/secretary.ts
@@ -1,4 +1,3 @@
-import { openai } from "@ai-sdk/openai";
 import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { scriptGeral } from "../scripts/geral";
@@ -8,6 +7,7 @@ import {
 	secretariaListRequirements,
 	secretariaUpsertEnrollment,
 } from "../tools";
+import { openai } from "../utils/openai";
 
 export const SecretaryAgent = new Agent({
 	name: "Anne",

--- a/src/retriever/qdrant-retriever.ts
+++ b/src/retriever/qdrant-retriever.ts
@@ -3,15 +3,10 @@ import {
 	BaseRetriever,
 	type RetrieveOptions,
 } from "@voltagent/core";
-import OpenAI from "openai";
+import { EMBED_MODEL, openaiClient } from "../utils/openai";
 import { QDRANT_COLLECTION, qdrant } from "../vector/qdrant";
 
-const openaiApiKey = process.env.OPENAI_API_KEY;
-if (!openaiApiKey) {
-	throw new Error("OPENAI_API_KEY is not set");
-}
-const openai = new OpenAI({ apiKey: openaiApiKey });
-const EMBED_MODEL = process.env.EMBED_MODEL ?? "text-embedding-3-small";
+const openai = openaiClient;
 
 async function embed(text: string) {
 	const r = await openai.embeddings.create({ model: EMBED_MODEL, input: text });

--- a/src/services/agent-trainning.ts
+++ b/src/services/agent-trainning.ts
@@ -1,15 +1,10 @@
 import { $Enums } from "@prisma/client";
-import OpenAI from "openai";
+import { EMBED_MODEL, openaiClient } from "../utils/openai";
 import { prisma } from "../utils/prisma";
 import { QDRANT_COLLECTION, ensureCollection, qdrant } from "../vector/qdrant";
 import { loadDocumentText } from "./doc-loader";
 
-const openaiApiKey = process.env.OPENAI_API_KEY;
-if (!openaiApiKey) {
-	throw new Error("OPENAI_API_KEY is not set");
-}
-const openai = new OpenAI({ apiKey: openaiApiKey });
-const EMBED_MODEL = process.env.EMBED_MODEL ?? "text-embedding-3-small";
+const openai = openaiClient;
 
 function chunkText(s: string, size = 1800, overlap = 400) {
 	if (!s) return [];

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -1,0 +1,13 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import OpenAI from "openai";
+
+const apiKey = process.env.OPENAI_API_KEY?.trim();
+if (!apiKey) {
+	throw new Error("OPENAI_API_KEY is not set");
+}
+
+export const openai = createOpenAI({ apiKey });
+
+export const openaiClient = new OpenAI({ apiKey });
+
+export const EMBED_MODEL = process.env.EMBED_MODEL ?? "text-embedding-3-small";


### PR DESCRIPTION
## Summary
- centralize OpenAI client setup with trimmed API key
- use shared OpenAI helpers across agents, services, and retrievers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af6969f1e48328bf1bda2f3bf826b2