### PR TITLE
feat: integrate secretary and finance with tuition calculator

### DIFF
--- a/src/agents/financeiro.ts
+++ b/src/agents/financeiro.ts
@@ -2,15 +2,16 @@ import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { FinanceiroScript } from "../scripts/financeiro-script";
 import { scriptGeral } from "../scripts/geral";
-import { openai } from "../utils/openai";
+import { financeiroCalcularMensalidades } from "../tools";
 import { memoryStorage } from "../utils/memory";
+import { openai } from "../utils/openai";
 
 export const FinanceiroAgent = new Agent({
 	name: "Fiona",
 	instructions: `${FinanceiroScript} ${scriptGeral}`,
 	llm: new VercelAIProvider(),
 	model: openai("gpt-4o-mini"),
-	tools: [],
+	tools: [financeiroCalcularMensalidades],
 	subAgents: [],
 	purpose: "Agente financeiro que gerencia pagamentos e recebimentos",
 	userContext: new Map([["environment", "production"]]),

--- a/src/agents/secretary.ts
+++ b/src/agents/secretary.ts
@@ -7,8 +7,9 @@ import {
 	secretariaListRequirements,
 	secretariaUpsertEnrollment,
 } from "../tools";
-import { openai } from "../utils/openai";
 import { memoryStorage } from "../utils/memory";
+import { openai } from "../utils/openai";
+import { FinanceiroAgent } from "./financeiro";
 
 export const SecretaryAgent = new Agent({
 	name: "Anne",
@@ -20,7 +21,7 @@ export const SecretaryAgent = new Agent({
 		secretariaGetEnrollmentStatus,
 		secretariaListRequirements,
 	],
-	subAgents: [],
+	subAgents: [FinanceiroAgent],
 	purpose: "Agente de secretária que faz a gestão de documentos e matrículas",
 	userContext: new Map([["environment", "production"]]),
 	memory: memoryStorage,

--- a/src/tools/financeiro/index.ts
+++ b/src/tools/financeiro/index.ts
@@ -28,26 +28,37 @@ export const financeiroEmitCharge = createTool({
 		description,
 	}) => {
 		// Inserir cobrança no Postgres (tabela payments), vinculada a um plano
-		const resolvedDue = dueDate ? new Date(dueDate) : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+		const resolvedDue = dueDate
+			? new Date(dueDate)
+			: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
 		let resolvedPlanId: string | null = planId ?? null;
 
 		if (!resolvedPlanId && studentRef) {
 			// Tentar resolver pelo sponsor diretamente
-			const bySponsor = await prisma.plans.findFirst({ where: { sponsorId: studentRef } });
+			const bySponsor = await prisma.plans.findFirst({
+				where: { sponsorId: studentRef },
+			});
 			if (bySponsor) {
 				resolvedPlanId = bySponsor.id;
 			} else {
 				// Tentar resolver via relação Responsible usando studentId
-				const rel = await prisma.responsible.findFirst({ where: { studentId: studentRef } });
+				const rel = await prisma.responsible.findFirst({
+					where: { studentId: studentRef },
+				});
 				if (rel) {
-					const byRel = await prisma.plans.findFirst({ where: { sponsorId: rel.sponsorId } });
+					const byRel = await prisma.plans.findFirst({
+						where: { sponsorId: rel.sponsorId },
+					});
 					if (byRel) resolvedPlanId = byRel.id;
 				}
 			}
 		}
 
 		if (!resolvedPlanId) {
-			return { ok: false as const, error: "Plano não encontrado para a referência informada" };
+			return {
+				ok: false as const,
+				error: "Plano não encontrado para a referência informada",
+			};
 		}
 
 		const created = await prisma.payment.create({
@@ -100,6 +111,113 @@ export const financeiroGetPaymentStatus = createTool({
 			status: "aguardando",
 			amount: 0,
 			method: "PIX" as const,
+		};
+	},
+});
+
+// -----------------------------------------------------------------------------
+// Cálculo de mensalidades e matrícula
+
+const alunoSchema = z.object({
+	nome: z.string().describe("nome do aluno"),
+	valorBase: z.number().describe("mensalidade base"),
+	pctPontualidade: z.number().describe("% de desconto de pontualidade"),
+	aplicaIrmaosAposPontualidade: z
+		.boolean()
+		.describe("se o desconto de irmãos incide após pontualidade"),
+});
+
+const regraIrmaosSchema = z.object({
+	tipo: z.enum(["A", "B", "C"]).describe("tipo de regra"),
+	percentuais: z.array(z.number()).optional().describe("percentuais por aluno"),
+	percentualFamilia: z
+		.number()
+		.optional()
+		.describe("percentual único sobre o total"),
+	valorFixo: z.number().optional().describe("valor fixo por irmão adicional"),
+});
+
+export const financeiroCalcularMensalidades = createTool({
+	name: "financeiro_calcular_mensalidades",
+	description: "calcula valores por aluno e família com descontos",
+	parameters: z.object({
+		alunos: z.array(alunoSchema),
+		regraIrmaos: regraIrmaosSchema.optional(),
+	}),
+	execute: async ({ alunos, regraIrmaos }) => {
+		const detalhes = alunos.map((a) => {
+			const descontoPont = a.valorBase * a.pctPontualidade;
+			const baseIrmaos = a.aplicaIrmaosAposPontualidade
+				? a.valorBase - descontoPont
+				: a.valorBase;
+			return {
+				nome: a.nome,
+				valorBase: a.valorBase,
+				descontoPontualidade: descontoPont,
+				baseIrmaos,
+			};
+		});
+
+		const somaBases = detalhes.reduce((s, a) => s + a.valorBase, 0);
+		const descontoPontTotal = detalhes.reduce(
+			(s, a) => s + a.descontoPontualidade,
+			0,
+		);
+
+		const somaBaseIrmaos = detalhes.reduce((s, a) => s + a.baseIrmaos, 0);
+
+		const descontosIrmaos = new Array(detalhes.length).fill(0);
+		let descontoIrmaosTotal = 0;
+
+		if (regraIrmaos) {
+			if (regraIrmaos.tipo === "A") {
+				const ordenados = detalhes
+					.map((a, i) => ({ ...a, index: i }))
+					.sort((a, b) => a.baseIrmaos - b.baseIrmaos);
+				for (let i = 1; i < ordenados.length; i++) {
+					const pct =
+						regraIrmaos.percentuais?.[i - 1] ??
+						regraIrmaos.percentuais?.[regraIrmaos.percentuais.length - 1] ??
+						0;
+					const desc = ordenados[i].baseIrmaos * pct;
+					descontosIrmaos[ordenados[i].index] = desc;
+					descontoIrmaosTotal += desc;
+				}
+			} else if (regraIrmaos.tipo === "B") {
+				const pct = regraIrmaos.percentualFamilia ?? 0;
+				descontoIrmaosTotal = somaBaseIrmaos * pct;
+				detalhes.forEach((a, idx) => {
+					descontosIrmaos[idx] =
+						descontoIrmaosTotal * (a.baseIrmaos / somaBaseIrmaos);
+				});
+			} else if (regraIrmaos.tipo === "C") {
+				const valor = regraIrmaos.valorFixo ?? 0;
+				descontoIrmaosTotal = valor * Math.max(detalhes.length - 1, 0);
+				detalhes.forEach((a, idx) => {
+					descontosIrmaos[idx] =
+						descontoIrmaosTotal * (a.baseIrmaos / somaBaseIrmaos);
+				});
+			}
+		}
+
+		const alunosOut = detalhes.map((a, idx) => ({
+			nome: a.nome,
+			valorBase: a.valorBase,
+			descontoPontualidade: a.descontoPontualidade,
+			descontoIrmaos: descontosIrmaos[idx],
+			totalAluno: a.valorBase - a.descontoPontualidade - descontosIrmaos[idx],
+		}));
+
+		const totalFamilia = somaBases - descontoPontTotal - descontoIrmaosTotal;
+
+		return {
+			alunos: alunosOut,
+			resumoFamilia: {
+				somaBases,
+				descontoPontualidadeTotal: descontoPontTotal,
+				descontoIrmaosTotal,
+				totalFamilia,
+			},
 		};
 	},
 });


### PR DESCRIPTION
## Summary
- allow secretary agent to delegate to finance agent
- add financial tuition calculator tool and wire it into finance agent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Import statements could be sorted)*
- `npx biome check src/agents/financeiro.ts src/agents/secretary.ts src/tools/financeiro/index.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5b47be7f08328a397f0af98115e2b