### PR TITLE
feat: expand financeiro agent capabilities

### DIFF
--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -8,7 +8,13 @@ import type { Tool } from "@voltagent/core";
 import {
 	financeiroConfirmPayment,
 	financeiroEmitCharge,
+	financeiroGetPaymentHistory,
 	financeiroGetPaymentStatus,
+	financeiroGetScholarshipInfo,
+	financeiroListAdditionalFees,
+	financeiroListBoletos,
+	financeiroListConvenios,
+	financeiroRegisterNegotiation,
 	logisticaTool,
 	sdrCreateLead,
 	sdrLogInteraction,
@@ -18,8 +24,8 @@ import {
 	secretariaUpsertEnrollment,
 } from "../tools";
 
-import { prisma } from "../utils/prisma";
 import { memoryStorage } from "../utils/memory";
+import { prisma } from "../utils/prisma";
 
 // biome-ignore lint/suspicious/noExplicitAny: generic tool mapping
 const TOOLS_BY_TYPE: Partial<Record<AgentType, Tool<any, any>[]>> = {
@@ -32,6 +38,12 @@ const TOOLS_BY_TYPE: Partial<Record<AgentType, Tool<any, any>[]>> = {
 		financeiroEmitCharge,
 		financeiroConfirmPayment,
 		financeiroGetPaymentStatus,
+		financeiroListAdditionalFees,
+		financeiroListBoletos,
+		financeiroGetPaymentHistory,
+		financeiroGetScholarshipInfo,
+		financeiroListConvenios,
+		financeiroRegisterNegotiation,
 	],
 	SDR: [sdrCreateLead, sdrUpdateStage, sdrLogInteraction],
 	LOGISTICA: [logisticaTool],

--- a/src/agents/financeiro.ts
+++ b/src/agents/financeiro.ts
@@ -2,7 +2,15 @@ import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { FinanceiroScript } from "../scripts/financeiro-script";
 import { scriptGeral } from "../scripts/geral";
-import { financeiroCalcularMensalidades } from "../tools";
+import {
+	financeiroCalcularMensalidades,
+	financeiroGetPaymentHistory,
+	financeiroGetScholarshipInfo,
+	financeiroListAdditionalFees,
+	financeiroListBoletos,
+	financeiroListConvenios,
+	financeiroRegisterNegotiation,
+} from "../tools";
 import { memoryStorage } from "../utils/memory";
 import { openai } from "../utils/openai";
 
@@ -11,7 +19,15 @@ export const FinanceiroAgent = new Agent({
 	instructions: `${FinanceiroScript} ${scriptGeral}`,
 	llm: new VercelAIProvider(),
 	model: openai("gpt-4o-mini"),
-	tools: [financeiroCalcularMensalidades],
+	tools: [
+		financeiroCalcularMensalidades,
+		financeiroListAdditionalFees,
+		financeiroListBoletos,
+		financeiroGetPaymentHistory,
+		financeiroGetScholarshipInfo,
+		financeiroListConvenios,
+		financeiroRegisterNegotiation,
+	],
 	subAgents: [],
 	purpose: "Agente financeiro que gerencia pagamentos e recebimentos",
 	userContext: new Map([["environment", "production"]]),


### PR DESCRIPTION
## Summary
- add tools for listing taxas adicionais, boletos, histórico de pagamentos, bolsas, convênios e negociações
- expose new financial tools on Financeiro agent and factory

## Testing
- `npm run lint` *(fails: Import statements could be sorted)*
- `npx biome check src/agents/financeiro.ts src/agents/factory.ts src/tools/financeiro/index.ts`
- `npm run typecheck`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5dbe6ab788328b2cea1ca2002c26e