### PR TITLE
feat: persist selected agent for conversations

### DIFF
--- a/prisma/migrations/20251120120000_conversation_agents/migration.sql
+++ b/prisma/migrations/20251120120000_conversation_agents/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "public"."conversation_agents" (
+    "conversationId" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "conversation_agents_pkey" PRIMARY KEY ("conversationId")
+);
+
+-- CreateIndex
+CREATE INDEX "conversation_agents_agentId_idx" ON "public"."conversation_agents"("agentId");
+
+-- AddForeignKey
+ALTER TABLE "public"."conversation_agents" ADD CONSTRAINT "conversation_agents_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -274,6 +274,7 @@ model Agent {
   rulesTo           Rule[]          @relation("RuleTo")
   trainingJobs      TrainingJob[]
   documents         AgentDocument[] // relação N:N via pivot
+  conversationAgents ConversationAgent[]
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
 
@@ -306,6 +307,16 @@ model AgentTag {
 
   @@unique([agentId, tag])
   @@index([tag])
+}
+
+model ConversationAgent {
+  conversationId String @id
+  agentId        String
+  agent          Agent  @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  updatedAt      DateTime @updatedAt
+
+  @@map("conversation_agents")
+  @@index([agentId])
 }
 
 model Team {

--- a/src/agents/logistica.ts
+++ b/src/agents/logistica.ts
@@ -2,8 +2,8 @@ import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { scriptGeral } from "../scripts/geral";
 import { LogisticaScript } from "../scripts/logistica-script";
-import { openai } from "../utils/openai";
 import { memoryStorage } from "../utils/memory";
+import { openai } from "../utils/openai";
 
 export const LogisticaAgent = new Agent({
 	name: "Leo",

--- a/src/agents/sdr.ts
+++ b/src/agents/sdr.ts
@@ -2,8 +2,8 @@ import { Agent, InMemoryStorage } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { scriptGeral } from "../scripts/geral";
 import { SRDScript } from "../scripts/sdr-script";
-import { openai } from "../utils/openai";
 import { memoryStorage } from "../utils/memory";
+import { openai } from "../utils/openai";
 
 export const SDRAgent = new Agent({
 	name: "SOFIA",

--- a/src/endpoints/agents.ts
+++ b/src/endpoints/agents.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from "node:crypto";
 import type { AgentStatus, AgentType, Prisma } from "@prisma/client";
 import type { CustomEndpointDefinition } from "@voltagent/core";
 import type { Context } from "hono";
 import { z } from "zod";
 import { prisma } from "../utils/prisma";
-import { randomUUID } from "node:crypto";
 
 // ---- mapeadores (front -> enums do Prisma)
 const mapTipo = (t: string): AgentType => {

--- a/src/endpoints/conversations.ts
+++ b/src/endpoints/conversations.ts
@@ -1,69 +1,79 @@
 import type { CustomEndpointDefinition } from "@voltagent/core";
 import type { Context } from "hono";
 import { memoryStorage } from "../utils/memory";
+import { prisma } from "../utils/prisma";
 
 function toInt(v: string | undefined, def: number): number {
-  const n = v ? parseInt(v, 10) : NaN;
-  return Number.isFinite(n) ? n : def;
+	const n = v ? Number.parseInt(v, 10) : Number.NaN;
+	return Number.isFinite(n) ? n : def;
 }
 
 export const conversationEndpoints: CustomEndpointDefinition[] = [
-  // List user conversations (with optional resourceId filter)
-  {
-    path: "/api/conversations",
-    method: "get" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const userId = c.req.header("x-user-id");
-      if (!userId)
-        return c.json({ success: false, message: "missing userId" }, 401);
+	// List user conversations (with optional resourceId filter)
+	{
+		path: "/api/conversations",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const limit = toInt(c.req.query("limit"), 50);
-      const offset = toInt(c.req.query("offset"), 0);
-      const orderBy = (c.req.query("orderBy") || "updated_at") as
-        | "created_at"
-        | "updated_at"
-        | "title";
-      const orderDirection = (c.req.query("orderDirection") || "DESC") as
-        | "ASC"
-        | "DESC";
-      const resourceId = c.req.query("resourceId") || undefined;
+			const limit = toInt(c.req.query("limit"), 50);
+			const offset = toInt(c.req.query("offset"), 0);
+			const orderBy = (c.req.query("orderBy") || "updated_at") as
+				| "created_at"
+				| "updated_at"
+				| "title";
+			const orderDirection = (c.req.query("orderDirection") || "DESC") as
+				| "ASC"
+				| "DESC";
+			const resourceId = c.req.query("resourceId") || undefined;
 
-      const conversations = await memoryStorage.queryConversations({
-        userId,
-        resourceId,
-        limit,
-        offset,
-        orderBy,
-        orderDirection,
-      });
+			const conversations = await memoryStorage.queryConversations({
+				userId,
+				resourceId,
+				limit,
+				offset,
+				orderBy,
+				orderDirection,
+			});
 
-      return c.json({ success: true, data: conversations });
-    },
-    description: "[privada] lista conversas do usuário (filtro opcional por resourceId)",
-  },
+			return c.json({ success: true, data: conversations });
+		},
+		description:
+			"[privada] lista conversas do usuário (filtro opcional por resourceId)",
+	},
 
-  // Get messages for a conversation
-  {
-    path: "/api/conversations/:conversationId/messages",
-    method: "get" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const userId = c.req.header("x-user-id");
-      if (!userId)
-        return c.json({ success: false, message: "missing userId" }, 401);
+	// Get messages for a conversation
+	{
+		path: "/api/conversations/:conversationId/messages",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const userId = c.req.header("x-user-id");
+			if (!userId)
+				return c.json({ success: false, message: "missing userId" }, 401);
 
-      const conversationId = c.req.param("conversationId");
-      const limit = toInt(c.req.query("limit"), 100);
-      const offset = toInt(c.req.query("offset"), 0);
+			const conversationId = c.req.param("conversationId");
+			const limit = toInt(c.req.query("limit"), 100);
+			const offset = toInt(c.req.query("offset"), 0);
 
-      // Optionally you could verify ownership of the conversation here if provider exposes it.
-      const messages = await memoryStorage.getConversationMessages(
-        conversationId,
-        { limit, offset },
-      );
+			// Optionally you could verify ownership of the conversation here if provider exposes it.
+			const [messages, mapping] = await Promise.all([
+				memoryStorage.getConversationMessages(conversationId, {
+					limit,
+					offset,
+				}),
+				prisma.conversationAgent.findUnique({
+					where: { conversationId },
+					include: { agent: { select: { id: true, nome: true, tipo: true } } },
+				}),
+			]);
 
-      return c.json({ success: true, data: messages });
-    },
-    description: "[privada] lista mensagens de uma conversa",
-  },
+			return c.json({
+				success: true,
+				data: { messages, agent: mapping?.agent ?? null },
+			});
+		},
+		description: "[privada] lista mensagens de uma conversa",
+	},
 ];
-

--- a/src/endpoints/financeiro.ts
+++ b/src/endpoints/financeiro.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { CustomEndpointDefinition } from "@voltagent/core";
 import type { Context } from "hono";
 import { FinanceiroChat } from "../agents/financeiro";
-import { randomUUID } from "node:crypto";
 
 export const financeiroEndpoints: CustomEndpointDefinition[] = [
 	{
@@ -10,7 +10,10 @@ export const financeiroEndpoints: CustomEndpointDefinition[] = [
 		handler: async (c: Context): Promise<Response> => {
 			const body = await c.req.json();
 			const { input, userId, conversationId } = body;
-			const convId = conversationId && conversationId.length > 0 ? conversationId : randomUUID();
+			const convId =
+				conversationId && conversationId.length > 0
+					? conversationId
+					: randomUUID();
 
 			try {
 				const response = await FinanceiroChat(input, userId, convId);

--- a/src/endpoints/logistica.ts
+++ b/src/endpoints/logistica.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { CustomEndpointDefinition } from "@voltagent/core";
 import type { Context } from "hono";
 import { LogisticaChat } from "../agents/logistica";
-import { randomUUID } from "node:crypto";
 
 export const logisticaEndpoints: CustomEndpointDefinition[] = [
 	{
@@ -10,7 +10,10 @@ export const logisticaEndpoints: CustomEndpointDefinition[] = [
 		handler: async (c: Context): Promise<Response> => {
 			const body = await c.req.json();
 			const { input, userId, conversationId } = body;
-			const convId = conversationId && conversationId.length > 0 ? conversationId : randomUUID();
+			const convId =
+				conversationId && conversationId.length > 0
+					? conversationId
+					: randomUUID();
 
 			try {
 				const response = await LogisticaChat(input, userId, convId);

--- a/src/endpoints/sdr.ts
+++ b/src/endpoints/sdr.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { CustomEndpointDefinition } from "@voltagent/core";
 import type { Context } from "hono";
 import { SDRChat } from "../agents/sdr";
-import { randomUUID } from "node:crypto";
 
 export const srdEndpoints: CustomEndpointDefinition[] = [
 	{
@@ -10,7 +10,10 @@ export const srdEndpoints: CustomEndpointDefinition[] = [
 		handler: async (c: Context): Promise<Response> => {
 			const body = await c.req.json();
 			const { input, userId, conversationId } = body;
-			const convId = conversationId && conversationId.length > 0 ? conversationId : randomUUID();
+			const convId =
+				conversationId && conversationId.length > 0
+					? conversationId
+					: randomUUID();
 
 			// pegue os dados do a
 			try {

--- a/src/endpoints/secretary.ts
+++ b/src/endpoints/secretary.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { CustomEndpointDefinition } from "@voltagent/core";
 import type { Context } from "hono";
 import { SecretaryChat } from "../agents/secretary";
-import { randomUUID } from "node:crypto";
 
 export const secretaryEndpoints: CustomEndpointDefinition[] = [
 	{
@@ -10,7 +10,10 @@ export const secretaryEndpoints: CustomEndpointDefinition[] = [
 		handler: async (c: Context): Promise<Response> => {
 			const body = await c.req.json();
 			const { input, userId, conversationId } = body;
-			const convId = conversationId && conversationId.length > 0 ? conversationId : randomUUID();
+			const convId =
+				conversationId && conversationId.length > 0
+					? conversationId
+					: randomUUID();
 
 			try {
 				const response = await SecretaryChat(input, userId, convId);

--- a/src/endpoints/wa.ts
+++ b/src/endpoints/wa.ts
@@ -1,323 +1,405 @@
+import { AgentType } from "@prisma/client";
 import type { CustomEndpointDefinition } from "@voltagent/core";
 import type { Context } from "hono";
-import { prisma } from "../utils/prisma";
-import { ensureInstanceAccess } from "../utils/auth";
 import { sendTextEvolution } from "../services/evolution";
+import { ensureInstanceAccess } from "../utils/auth";
+import { prisma } from "../utils/prisma";
 
+// biome-ignore lint/suspicious/noExplicitAny: flexible message shape
 function pickText(msg: any): string | undefined {
-  const m = msg?.message || msg;
-  return (
-    m?.conversation ||
-    m?.extendedTextMessage?.text ||
-    m?.imageMessage?.caption ||
-    m?.videoMessage?.caption ||
-    m?.templateButtonReplyMessage?.selectedId ||
-    m?.buttonsResponseMessage?.selectedButtonId ||
-    m?.listResponseMessage?.title ||
-    undefined
-  );
+	const m = msg?.message || msg;
+	return (
+		m?.conversation ||
+		m?.extendedTextMessage?.text ||
+		m?.imageMessage?.caption ||
+		m?.videoMessage?.caption ||
+		m?.templateButtonReplyMessage?.selectedId ||
+		m?.buttonsResponseMessage?.selectedButtonId ||
+		m?.listResponseMessage?.title ||
+		undefined
+	);
 }
 
 async function saveMessage(doc: {
-  instance: string;
-  remoteJid: string;
-  fromMe?: boolean;
-  messageId?: string;
-  pushName?: string;
-  body?: string;
-  timestamp?: Date | number | string;
+	instance: string;
+	remoteJid: string;
+	fromMe?: boolean;
+	messageId?: string;
+	pushName?: string;
+	body?: string;
+	timestamp?: Date | number | string;
 }) {
-  // Idempotent-ish: avoid duplicates by messageId+instance
-  if (doc.messageId) {
-    const existing = await prisma.messages.findFirst({
-      where: { messageId: doc.messageId, instance: doc.instance },
-      select: { id: true },
-    });
-    if (existing) return existing;
-  }
-  return prisma.messages.create({
-    data: {
-      instance: doc.instance,
-      remoteJid: doc.remoteJid,
-      fromMe: doc.fromMe,
-      messageId: doc.messageId,
-      pushName: doc.pushName,
-      message: doc.body,
-      sendAt: doc.timestamp ? new Date(doc.timestamp) : undefined,
-    },
-  });
+	// Idempotent-ish: avoid duplicates by messageId+instance
+	if (doc.messageId) {
+		const existing = await prisma.messages.findFirst({
+			where: { messageId: doc.messageId, instance: doc.instance },
+			select: { id: true },
+		});
+		if (existing) return existing;
+	}
+	return prisma.messages.create({
+		data: {
+			instance: doc.instance,
+			remoteJid: doc.remoteJid,
+			fromMe: doc.fromMe,
+			messageId: doc.messageId,
+			pushName: doc.pushName,
+			message: doc.body,
+			sendAt: doc.timestamp ? new Date(doc.timestamp) : undefined,
+		},
+	});
 }
 
 export const waEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/instances/:instance/verify",
-    method: "get" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const instance = c.req.param("instance");
-      try {
-        const { userId } = await ensureInstanceAccess(c, instance);
-        const last = await prisma.messages.findFirst({
-          where: { instance },
-          orderBy: { sendAt: "desc" },
-          select: { sendAt: true },
-        });
-        return c.json(
-          {
-            success: true,
-            data: {
-              belongs: true,
-              userId,
-              hasMessages: Boolean(last?.sendAt),
-              lastMessageAt: last?.sendAt ?? null,
-            },
-          },
-          200,
-        );
-      } catch (err: unknown) {
-        return c.json({ success: true, data: { belongs: false } }, 200);
-      }
-    },
-    description: "[auth] Verify if user owns instance and if it has activity",
-  },
-  {
-    path: "/api/wa/webhook",
-    method: "post" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const body = await c.req.json().catch(() => ({}));
-      const instance = (body.instanceName || body.instance || c.req.query("instance") || "").toString();
-      if (!instance) {
-        return c.json({ success: false, message: "missing instance" }, 400);
-      }
+	{
+		path: "/instances/:instance/verify",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const instance = c.req.param("instance");
+			try {
+				const { userId } = await ensureInstanceAccess(c, instance);
+				const last = await prisma.messages.findFirst({
+					where: { instance },
+					orderBy: { sendAt: "desc" },
+					select: { sendAt: true },
+				});
+				return c.json(
+					{
+						success: true,
+						data: {
+							belongs: true,
+							userId,
+							hasMessages: Boolean(last?.sendAt),
+							lastMessageAt: last?.sendAt ?? null,
+						},
+					},
+					200,
+				);
+			} catch (err: unknown) {
+				return c.json({ success: true, data: { belongs: false } }, 200);
+			}
+		},
+		description: "[auth] Verify if user owns instance and if it has activity",
+	},
+	{
+		path: "/api/wa/webhook",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			// biome-ignore lint/suspicious/noExplicitAny: unknown body shape
+			const body = await c.req.json().catch(() => ({}) as any);
+			const instance = (
+				body.instanceName ||
+				body.instance ||
+				c.req.query("instance") ||
+				""
+			).toString();
+			if (!instance) {
+				return c.json({ success: false, message: "missing instance" }, 400);
+			}
 
-      const items: any[] =
-        body?.parsedMessages ||
-        body?.messages ||
-        body?.data?.messages ||
-        Array.isArray(body) ? body : [];
+			// biome-ignore lint/suspicious/noExplicitAny: flexible input
+			const items: any[] =
+				body?.parsedMessages ||
+				body?.messages ||
+				body?.data?.messages ||
+				(Array.isArray(body) ? body : []);
 
-      if (!Array.isArray(items) || items.length === 0) {
-        return c.json({ success: true, message: "no-op" }, 200);
-      }
+			if (!Array.isArray(items) || items.length === 0) {
+				return c.json({ success: true, message: "no-op" }, 200);
+			}
 
-      try {
-        const saved = [] as any[];
-        for (const it of items) {
-          // Support two shapes: our ParsedMessage or Evolution's Baileys-ish event
-          if (it?.remoteJid || it?.message) {
-            const msg = await saveMessage({
-              instance,
-              remoteJid: (it.remoteJid || it.key?.remoteJid || "").toString(),
-              fromMe: Boolean(it.fromMe ?? it.key?.fromMe),
-              messageId: it.messageId || it.key?.id,
-              pushName: it.pushName || it?.participant || undefined,
-              body: it.message || pickText(it),
-              timestamp: it.sentAt || it.messageTimestamp || Date.now(),
-            });
-            saved.push(msg);
-          }
-        }
+			try {
+				// biome-ignore lint/suspicious/noExplicitAny: flexible message shape
+				const saved: any[] = [];
+				for (const it of items) {
+					// Support two shapes: our ParsedMessage or Evolution's Baileys-ish event
+					if (it?.remoteJid || it?.message) {
+						const msg = await saveMessage({
+							instance,
+							remoteJid: (it.remoteJid || it.key?.remoteJid || "").toString(),
+							fromMe: Boolean(it.fromMe ?? it.key?.fromMe),
+							messageId: it.messageId || it.key?.id,
+							pushName: it.pushName || it?.participant || undefined,
+							body: it.message || pickText(it),
+							timestamp: it.sentAt || it.messageTimestamp || Date.now(),
+						});
+						saved.push(msg);
+					}
+				}
 
-        // Route to the right agent: primary WHATSAPP agent of the owner; fallback to Secretary
-        try {
-          if (saved.length) {
-            const owner = await prisma.whatsappNumbers.findFirst({
-              where: { instance },
-              select: { userId: true },
-            });
-            const input = saved.map((m) => m.message).filter(Boolean).join(". ");
-            const userId = saved[0]?.remoteJid;
-            const sendAt = saved[0]?.sendAt as Date | undefined;
-            const conversationId = saved[0]?.messageId && sendAt
-              ? `${saved[0].messageId}_${new Date(sendAt).getTime()}`
-              : "default_conversation";
+				// Route to the right agent: primary WHATSAPP agent of the owner; fallback to Secretary
+				try {
+					if (saved.length) {
+						const owner = await prisma.whatsappNumbers.findFirst({
+							where: { instance },
+							select: { userId: true },
+						});
+						const input = saved
+							.map((m) => m.message)
+							.filter(Boolean)
+							.join(". ");
+						const userId = saved[0]?.remoteJid;
+						const sendAt = saved[0]?.sendAt as Date | undefined;
+						const conversationId =
+							saved[0]?.messageId && sendAt
+								? `${saved[0].messageId}_${new Date(sendAt).getTime()}`
+								: "default_conversation";
 
-            if (owner?.userId && input && userId) {
-              const primary = await prisma.agentChannel.findFirst({
-                where: {
-                  channel: "WHATSAPP",
-                  primary: true,
-                  agent: { ownerId: owner.userId, status: "ATIVO" },
-                },
-                select: { agentId: true },
-              });
+						if (owner?.userId && input && userId) {
+							const existing = await prisma.conversationAgent.findUnique({
+								where: { conversationId },
+								select: { agentId: true },
+							});
 
-              if (primary?.agentId) {
-                const { buildAgentFromDB } = await import("../agents/factory");
-                const agentInstance = await buildAgentFromDB(primary.agentId);
-                await agentInstance.generateText(input, { userId, conversationId });
-              } else {
-                const { SecretaryChat } = await import("../agents/secretary");
-                await SecretaryChat(input, userId, conversationId);
-              }
-            }
-          }
-        } catch (routeErr) {
-          console.error("routing error", routeErr);
-        }
+							if (existing?.agentId) {
+								const { buildAgentFromDB } = await import("../agents/factory");
+								const agentInstance = await buildAgentFromDB(existing.agentId);
+								await agentInstance.generateText(input, {
+									userId,
+									conversationId,
+								});
+							} else {
+								const primary = await prisma.agentChannel.findFirst({
+									where: {
+										channel: "WHATSAPP",
+										primary: true,
+										agent: { ownerId: owner.userId, status: "ATIVO" },
+									},
+									select: { agentId: true },
+								});
 
-        return c.json({ success: true, data: { count: saved.length } }, 201);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : "error";
-        return c.json({ success: false, message }, 400);
-      }
-    },
-    description: "[public] Evolution webhook: messages upsert/update",
-  },
+								let agentId: string | null = null;
+								if (primary?.agentId) {
+									const { buildAgentFromDB } = await import(
+										"../agents/factory"
+									);
+									const agentInstance = await buildAgentFromDB(primary.agentId);
+									await agentInstance.generateText(input, {
+										userId,
+										conversationId,
+									});
+									agentId = primary.agentId;
+								} else {
+									const { SecretaryChat } = await import("../agents/secretary");
+									await SecretaryChat(input, userId, conversationId);
+									const sec = await prisma.agent.findFirst({
+										where: {
+											ownerId: owner.userId,
+											tipo: AgentType.SECRETARIA,
+										},
+										select: { id: true },
+									});
+									agentId = sec?.id ?? null;
+								}
 
-  {
-    path: "/instances/:instance/chats",
-    method: "get" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const instance = c.req.param("instance");
-      const q = (c.req.query("q") || "").toString().toLowerCase();
-      const limit = Math.min(parseInt(c.req.query("limit") || "20", 10), 100);
-      const offset = Math.max(parseInt(c.req.query("offset") || "0", 10), 0);
+								if (agentId) {
+									await prisma.conversationAgent.upsert({
+										where: { conversationId },
+										update: { agentId },
+										create: { conversationId, agentId },
+									});
+								}
+							}
+						}
+					}
+				} catch (routeErr) {
+					console.error("routing error", routeErr);
+				}
 
-      try {
-        await ensureInstanceAccess(c, instance);
+				return c.json({ success: true, data: { count: saved.length } }, 201);
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : "error";
+				return c.json({ success: false, message }, 400);
+			}
+		},
+		description: "[public] Evolution webhook: messages upsert/update",
+	},
 
-        // Fetch recent messages for this instance, then reduce to chats by remoteJid
-        const recent = await prisma.messages.findMany({
-          where: { instance },
-          orderBy: { sendAt: "desc" },
-          take: 500,
-          select: {
-            id: true,
-            remoteJid: true,
-            fromMe: true,
-            message: true,
-            sendAt: true,
-            pushName: true,
-          },
-        });
+	{
+		path: "/instances/:instance/chats",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const instance = c.req.param("instance");
+			const q = (c.req.query("q") || "").toString().toLowerCase();
+			const limit = Math.min(
+				Number.parseInt(c.req.query("limit") || "20", 10),
+				100,
+			);
+			const offset = Math.max(
+				Number.parseInt(c.req.query("offset") || "0", 10),
+				0,
+			);
 
-        const map = new Map<string, typeof recent[number]>();
-        for (const m of recent) {
-          if (!map.has(m.remoteJid || "")) map.set(m.remoteJid || "", m);
-        }
+			try {
+				await ensureInstanceAccess(c, instance);
 
-        let rows = Array.from(map.values());
-        if (q) {
-          rows = rows.filter((r) =>
-            (r.pushName || "").toLowerCase().includes(q) || (r.remoteJid || "").toLowerCase().includes(q),
-          );
-        }
+				// Fetch recent messages for this instance, then reduce to chats by remoteJid
+				const recent = await prisma.messages.findMany({
+					where: { instance },
+					orderBy: { sendAt: "desc" },
+					take: 500,
+					select: {
+						id: true,
+						remoteJid: true,
+						fromMe: true,
+						message: true,
+						sendAt: true,
+						pushName: true,
+					},
+				});
 
-        const page = rows.slice(offset, offset + limit);
-        const data = page.map((r) => ({
-          id: r.remoteJid,
-          name: r.pushName || r.remoteJid,
-          unreadCount: 0, // no read-state tracking yet
-          lastMessage: { body: r.message, timestamp: r.sendAt },
-        }));
+				const map = new Map<string, (typeof recent)[number]>();
+				for (const m of recent) {
+					if (!map.has(m.remoteJid || "")) map.set(m.remoteJid || "", m);
+				}
 
-        return c.json({ success: true, data, total: rows.length }, 200);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : "error";
-        return c.json({ success: false, message }, 403);
-      }
-    },
-    description: "[auth] List chats for instance",
-  },
+				let rows = Array.from(map.values());
+				if (q) {
+					rows = rows.filter(
+						(r) =>
+							(r.pushName || "").toLowerCase().includes(q) ||
+							(r.remoteJid || "").toLowerCase().includes(q),
+					);
+				}
 
-  {
-    path: "/instances/:instance/messages",
-    method: "get" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const instance = c.req.param("instance");
-      const jid = (c.req.query("jid") || "").toString();
-      const limit = Math.min(parseInt(c.req.query("limit") || "50", 10), 200);
-      const offset = Math.max(parseInt(c.req.query("offset") || "0", 10), 0);
-      if (!jid) return c.json({ success: false, message: "missing jid" }, 400);
+				const page = rows.slice(offset, offset + limit);
+				const data = page.map((r) => ({
+					id: r.remoteJid,
+					name: r.pushName || r.remoteJid,
+					unreadCount: 0, // no read-state tracking yet
+					lastMessage: { body: r.message, timestamp: r.sendAt },
+				}));
 
-      try {
-        await ensureInstanceAccess(c, instance);
-        const items = await prisma.messages.findMany({
-          where: { instance, remoteJid: jid },
-          orderBy: { sendAt: "desc" },
-          skip: offset,
-          take: limit,
-          select: {
-            id: true,
-            fromMe: true,
-            message: true,
-            sendAt: true,
-            messageId: true,
-          },
-        });
-        const data = items.map((m) => ({
-          id: m.id,
-          key: { fromMe: m.fromMe },
-          body: m.message,
-          timestamp: m.sendAt,
-          messageId: m.messageId,
-        }));
-        return c.json({ success: true, data }, 200);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : "error";
-        return c.json({ success: false, message }, 403);
-      }
-    },
-    description: "[auth] List messages by jid",
-  },
+				return c.json({ success: true, data, total: rows.length }, 200);
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : "error";
+				return c.json({ success: false, message }, 403);
+			}
+		},
+		description: "[auth] List chats for instance",
+	},
 
-  {
-    path: "/instances/:instance/contact",
-    method: "get" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const instance = c.req.param("instance");
-      const jid = (c.req.query("jid") || "").toString();
-      if (!jid) return c.json({ success: false, message: "missing jid" }, 400);
-      try {
-        await ensureInstanceAccess(c, instance);
-        const m = await prisma.messages.findFirst({
-          where: { instance, remoteJid: jid },
-          orderBy: { sendAt: "desc" },
-          select: { pushName: true },
-        });
-        return c.json({ success: true, data: { jid, name: m?.pushName, pushName: m?.pushName } }, 200);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : "error";
-        return c.json({ success: false, message }, 403);
-      }
-    },
-    description: "[auth] Get contact by jid",
-  },
+	{
+		path: "/instances/:instance/messages",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const instance = c.req.param("instance");
+			const jid = (c.req.query("jid") || "").toString();
+			const limit = Math.min(
+				Number.parseInt(c.req.query("limit") || "50", 10),
+				200,
+			);
+			const offset = Math.max(
+				Number.parseInt(c.req.query("offset") || "0", 10),
+				0,
+			);
+			if (!jid) return c.json({ success: false, message: "missing jid" }, 400);
 
-  {
-    path: "/instances/:instance/send",
-    method: "post" as const,
-    handler: async (c: Context): Promise<Response> => {
-      const instance = c.req.param("instance");
-      const body = await c.req.json().catch(() => ({} as any));
-      const dest = String(body.number || body.to || body.jid || body.remoteJid || body.chatId || "").trim();
-      const msg = String(body.text || body.message || body.body || "").trim();
-      if (!dest || !msg) {
-        return c.json({ success: false, message: "missing to or text" }, 400);
-      }
-      try {
-        const { evoInstance } = await ensureInstanceAccess(c, instance);
-        const instanceName = evoInstance || instance;
-        const evoRes = await sendTextEvolution(instanceName, dest, msg);
-        const evoJson = await evoRes.json().catch(() => ({}));
-        if (!evoRes.ok) {
-          return c.json({ success: false, message: "evolution error", data: evoJson }, 502);
-        }
-        // Persist sent message (optional but useful)
-        await saveMessage({
-          instance,
-          remoteJid: dest,
-          fromMe: true,
-          messageId: evoJson?.key?.id || evoJson?.messageId || undefined,
-          body: msg,
-          timestamp: Date.now(),
-        });
-        return c.json({ success: true, data: evoJson }, 200);
-      } catch (e: unknown) {
-        console.error("send error", e);
-        return c.json({ success: false, message: "internal error" }, 500);
-      }
-    },
-    description: "[auth] Send text via Evolution and persist",
-  },
+			try {
+				await ensureInstanceAccess(c, instance);
+				const items = await prisma.messages.findMany({
+					where: { instance, remoteJid: jid },
+					orderBy: { sendAt: "desc" },
+					skip: offset,
+					take: limit,
+					select: {
+						id: true,
+						fromMe: true,
+						message: true,
+						sendAt: true,
+						messageId: true,
+					},
+				});
+				const data = items.map((m) => ({
+					id: m.id,
+					key: { fromMe: m.fromMe },
+					body: m.message,
+					timestamp: m.sendAt,
+					messageId: m.messageId,
+				}));
+				return c.json({ success: true, data }, 200);
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : "error";
+				return c.json({ success: false, message }, 403);
+			}
+		},
+		description: "[auth] List messages by jid",
+	},
+
+	{
+		path: "/instances/:instance/contact",
+		method: "get" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const instance = c.req.param("instance");
+			const jid = (c.req.query("jid") || "").toString();
+			if (!jid) return c.json({ success: false, message: "missing jid" }, 400);
+			try {
+				await ensureInstanceAccess(c, instance);
+				const m = await prisma.messages.findFirst({
+					where: { instance, remoteJid: jid },
+					orderBy: { sendAt: "desc" },
+					select: { pushName: true },
+				});
+				return c.json(
+					{
+						success: true,
+						data: { jid, name: m?.pushName, pushName: m?.pushName },
+					},
+					200,
+				);
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : "error";
+				return c.json({ success: false, message }, 403);
+			}
+		},
+		description: "[auth] Get contact by jid",
+	},
+
+	{
+		path: "/instances/:instance/send",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			const instance = c.req.param("instance");
+			// biome-ignore lint/suspicious/noExplicitAny: unknown body shape
+			const body = await c.req.json().catch(() => ({}) as any);
+			const dest = String(
+				body.number ||
+					body.to ||
+					body.jid ||
+					body.remoteJid ||
+					body.chatId ||
+					"",
+			).trim();
+			const msg = String(body.text || body.message || body.body || "").trim();
+			if (!dest || !msg) {
+				return c.json({ success: false, message: "missing to or text" }, 400);
+			}
+			try {
+				const { evoInstance } = await ensureInstanceAccess(c, instance);
+				const instanceName = evoInstance || instance;
+				const evoRes = await sendTextEvolution(instanceName, dest, msg);
+				const evoJson = await evoRes.json().catch(() => ({}));
+				if (!evoRes.ok) {
+					return c.json(
+						{ success: false, message: "evolution error", data: evoJson },
+						502,
+					);
+				}
+				// Persist sent message (optional but useful)
+				await saveMessage({
+					instance,
+					remoteJid: dest,
+					fromMe: true,
+					messageId: evoJson?.key?.id || evoJson?.messageId || undefined,
+					body: msg,
+					timestamp: Date.now(),
+				});
+				return c.json({ success: true, data: evoJson }, 200);
+			} catch (e: unknown) {
+				console.error("send error", e);
+				return c.json({ success: false, message: "internal error" }, 500);
+			}
+		},
+		description: "[auth] Send text via Evolution and persist",
+	},
 ];

--- a/src/services/evolution.ts
+++ b/src/services/evolution.ts
@@ -3,63 +3,84 @@ import "dotenv/config";
 
 const EVO_URL = process.env.EVOLUTION_URL || "";
 const EVO_API_KEY = process.env.EVO_API_KEY || process.env.EVO_APIKEY || "";
-const EVO_SENDTEXT_PATH_TMPL = process.env.EVOLUTION_SENDTEXT_PATH || "/message/sendText"; // supports {instance}
-const EVO_APIKEY_IN = (process.env.EVOLUTION_APIKEY_IN || "header").toLowerCase(); // 'header' | 'query'
+const EVO_SENDTEXT_PATH_TMPL =
+	process.env.EVOLUTION_SENDTEXT_PATH || "/message/sendText"; // supports {instance}
+const EVO_APIKEY_IN = (
+	process.env.EVOLUTION_APIKEY_IN || "header"
+).toLowerCase(); // 'header' | 'query'
 
 // Low-level: returns the raw Response so callers can inspect status/body
-export async function sendTextEvolution(instanceName: string, toOrJid: string, text: string) {
-  if (!EVO_URL || !EVO_API_KEY) throw new Error("missing EVOLUTION_URL or EVO_API_KEY env");
-  const base = EVO_URL.replace(/\/$/, "");
-  const numberPart = toOrJid.includes("@") ? toOrJid.split("@")[0] : toOrJid;
-  const digits = numberPart.replace(/[^0-9]/g, "");
+export async function sendTextEvolution(
+	instanceName: string,
+	toOrJid: string,
+	text: string,
+) {
+	if (!EVO_URL || !EVO_API_KEY)
+		throw new Error("missing EVOLUTION_URL or EVO_API_KEY env");
+	const base = EVO_URL.replace(/\/$/, "");
+	const numberPart = toOrJid.includes("@") ? toOrJid.split("@")[0] : toOrJid;
+	const digits = numberPart.replace(/[^0-9]/g, "");
 
-  const buildHeaders = (urlWithMaybeQuery: string) => {
-    const headers: Record<string, string> = { "content-type": "application/json" };
-    if (EVO_APIKEY_IN === "header") return { url: urlWithMaybeQuery, headers } as const;
-    const sep = urlWithMaybeQuery.includes("?") ? "&" : "?";
-    return { url: `${urlWithMaybeQuery}${sep}apikey=${encodeURIComponent(EVO_API_KEY)}`, headers } as const;
-  };
-  const applyApiKeyHeader = (h: Record<string, string>) => {
-    if (EVO_APIKEY_IN === "header") h["apikey"] = EVO_API_KEY;
-    return h;
-  };
+	const buildHeaders = (urlWithMaybeQuery: string) => {
+		const headers: Record<string, string> = {
+			"content-type": "application/json",
+		};
+		if (EVO_APIKEY_IN === "header")
+			return { url: urlWithMaybeQuery, headers } as const;
+		const sep = urlWithMaybeQuery.includes("?") ? "&" : "?";
+		return {
+			url: `${urlWithMaybeQuery}${sep}apikey=${encodeURIComponent(EVO_API_KEY)}`,
+			headers,
+		} as const;
+	};
+	const applyApiKeyHeader = (h: Record<string, string>) => {
+		if (EVO_APIKEY_IN === "header") h.apikey = EVO_API_KEY;
+		return h;
+	};
 
-  // 1) Prefer modern path: instance in URL
-  {
-    const pathV2 = `/message/sendText/${encodeURIComponent(instanceName)}`.replace(/^\/+/, "");
-    const { url, headers } = buildHeaders(`${base}/${pathV2}`);
-    const res = await fetch(url, {
-      method: "POST",
-      headers: applyApiKeyHeader(headers),
-      body: JSON.stringify({ number: digits, text }),
-    });
-    if (res.status !== 404) return res; // success or other error -> return as-is
-  }
+	// 1) Prefer modern path: instance in URL
+	{
+		const pathV2 =
+			`/message/sendText/${encodeURIComponent(instanceName)}`.replace(
+				/^\/+/,
+				"",
+			);
+		const { url, headers } = buildHeaders(`${base}/${pathV2}`);
+		const res = await fetch(url, {
+			method: "POST",
+			headers: applyApiKeyHeader(headers),
+			body: JSON.stringify({ number: digits, text }),
+		});
+		if (res.status !== 404) return res; // success or other error -> return as-is
+	}
 
-  // 2) Fallback legacy or configured path
-  {
-    const pathTmpl = (EVO_SENDTEXT_PATH_TMPL || "/message/sendText").replace(/^\/+/, "");
-    const pathLegacy = pathTmpl.includes("{instance}")
-      ? pathTmpl.replace("{instance}", encodeURIComponent(instanceName))
-      : pathTmpl;
-    const { url, headers } = buildHeaders(`${base}/${pathLegacy}`);
-    const body = pathTmpl.includes("{instance}")
-      ? { number: digits, text }
-      : { instanceName, number: digits, text };
-    return fetch(url, {
-      method: "POST",
-      headers: applyApiKeyHeader(headers),
-      body: JSON.stringify(body),
-    });
-  }
+	// 2) Fallback legacy or configured path
+	{
+		const pathTmpl = (EVO_SENDTEXT_PATH_TMPL || "/message/sendText").replace(
+			/^\/+/,
+			"",
+		);
+		const pathLegacy = pathTmpl.includes("{instance}")
+			? pathTmpl.replace("{instance}", encodeURIComponent(instanceName))
+			: pathTmpl;
+		const { url, headers } = buildHeaders(`${base}/${pathLegacy}`);
+		const body = pathTmpl.includes("{instance}")
+			? { number: digits, text }
+			: { instanceName, number: digits, text };
+		return fetch(url, {
+			method: "POST",
+			headers: applyApiKeyHeader(headers),
+			body: JSON.stringify(body),
+		});
+	}
 }
 
 // Back-compat helper (kept if needed elsewhere)
 export async function evoSendText(instance: string, to: string, text: string) {
-  const res = await sendTextEvolution(instance, to, text);
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`evolution sendText failed: ${res.status} ${body}`);
-  }
-  return res.json().catch(() => ({}));
+	const res = await sendTextEvolution(instance, to, text);
+	if (!res.ok) {
+		const body = await res.text().catch(() => "");
+		throw new Error(`evolution sendText failed: ${res.status} ${body}`);
+	}
+	return res.json().catch(() => ({}));
 }

--- a/src/tools/financeiro/index.ts
+++ b/src/tools/financeiro/index.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from "node:crypto";
 import { createTool } from "@voltagent/core";
 import { z } from "zod";
-import { prisma } from "../../utils/prisma";
-import { randomUUID } from "crypto";
 import { EMBED_MODEL, openaiClient } from "../../utils/openai";
-import { qdrant, QDRANT_COLLECTION } from "../../vector/qdrant";
+import { prisma } from "../../utils/prisma";
+import { QDRANT_COLLECTION, qdrant } from "../../vector/qdrant";
 
 const chargeParams = z
 	.object({
@@ -18,7 +18,7 @@ const chargeParams = z
 		message: "planId ou studentRef são obrigatórios",
 	});
 
-	// deve salvar no banco de dados e ser acessável pelo agente.
+// deve salvar no banco de dados e ser acessável pelo agente.
 export const financeiroEmitCharge = createTool({
 	name: "financeiro_emit_charge",
 	description: "emite uma cobrança para um plano ou estudante",
@@ -105,7 +105,8 @@ export const financeiroConfirmPayment = createTool({
 		if (!id) return { ok: false as const, error: "referência inválida" };
 
 		const exists = await prisma.payment.findUnique({ where: { id } });
-		if (!exists) return { ok: false as const, error: "pagamento não encontrado" };
+		if (!exists)
+			return { ok: false as const, error: "pagamento não encontrado" };
 
 		if (exists.status !== "PAID") {
 			await prisma.payment.update({
@@ -129,7 +130,12 @@ export const financeiroGetPaymentStatus = createTool({
 		const p = await prisma.payment.findUnique({ where: { id } });
 		if (!p) return { ok: false as const, error: "pagamento não encontrado" };
 
-		const status = p.status === "PAID" ? "pago" : p.status === "CANCELED" ? "cancelado" : "aguardando";
+		const status =
+			p.status === "PAID"
+				? "pago"
+				: p.status === "CANCELED"
+					? "cancelado"
+					: "aguardando";
 		return {
 			ok: true as const,
 			status,
@@ -254,113 +260,135 @@ export const financeiroListAdditionalFees = createTool({
 	name: "financeiro_list_taxas_adicionais",
 	description: "lista taxas adicionais como matrícula e material didático",
 	parameters: z.object({}),
-		execute: async () => {
-			// Consulta documentos via retriever (Qdrant) e extrai taxas por regex simples
-			const query =
-				"taxas adicionais matrícula rematrícula material didático atividades excursões mensalidades custos valores";
-			const emb = await openaiClient.embeddings.create({
-				model: EMBED_MODEL,
-				input: query,
-			});
-			const vector = emb.data[0].embedding as number[];
-			const results = (await qdrant.search(QDRANT_COLLECTION, {
-				vector,
-				limit: 8,
-				with_payload: true,
-				// Preferir RULE/CSV quando houver
-				filter: {
-					should: [
-						{ key: "kind", match: { value: "RULE" } },
-						{ key: "kind", match: { value: "CSV" } },
-					],
-				},
-			})) as Array<{
-				payload?: { text?: string; docName?: string; kind?: string };
-				score?: number;
-			}>;
+	execute: async () => {
+		// Consulta documentos via retriever (Qdrant) e extrai taxas por regex simples
+		const query =
+			"taxas adicionais matrícula rematrícula material didático atividades excursões mensalidades custos valores";
+		const emb = await openaiClient.embeddings.create({
+			model: EMBED_MODEL,
+			input: query,
+		});
+		const vector = emb.data[0].embedding as number[];
+		const results = (await qdrant.search(QDRANT_COLLECTION, {
+			vector,
+			limit: 8,
+			with_payload: true,
+			// Preferir RULE/CSV quando houver
+			filter: {
+				should: [
+					{ key: "kind", match: { value: "RULE" } },
+					{ key: "kind", match: { value: "CSV" } },
+				],
+			},
+		})) as Array<{
+			payload?: { text?: string; docName?: string; kind?: string };
+			score?: number;
+		}>;
 
-			// Regex por taxa
-			const patterns: Array<{ key: string; rx: RegExp }> = [
-				{ key: "matrícula", rx: /(matr[ií]cula)[^\d]*(\d+[\.,]?\d*)/i },
-				{ key: "rematrícula", rx: /(rematr[ií]cula)[^\d]*(\d+[\.,]?\d*)/i },
-				{
-					key: "material_didático",
-					rx: /(material(\s+did[aá]tico)?)[^\d]*(\d+[\.,]?\d*)/i,
-				},
-				{
-					key: "atividades_extracurriculares",
-					rx: /(atividades?\s*extra(curriculares)?)[^\d]*(\d+[\.,]?\d*)/i,
-				},
-				{ key: "excursões", rx: /(excurs[õo]es?)[^\d]*(\d+[\.,]?\d*)/i },
-			];
+		// Regex por taxa
+		const patterns: Array<{ key: string; rx: RegExp }> = [
+			{ key: "matrícula", rx: /(matr[ií]cula)[^\d]*(\d+[\.,]?\d*)/i },
+			{ key: "rematrícula", rx: /(rematr[ií]cula)[^\d]*(\d+[\.,]?\d*)/i },
+			{
+				key: "material_didático",
+				rx: /(material(\s+did[aá]tico)?)[^\d]*(\d+[\.,]?\d*)/i,
+			},
+			{
+				key: "atividades_extracurriculares",
+				rx: /(atividades?\s*extra(curriculares)?)[^\d]*(\d+[\.,]?\d*)/i,
+			},
+			{ key: "excursões", rx: /(excurs[õo]es?)[^\d]*(\d+[\.,]?\d*)/i },
+		];
 
-			// Mapa agregado: mantém o menor valor e a melhor referência
-			const feeMap = new Map<string, { valor: number; source: string; score: number }>();
-			results.forEach((r, idx) => {
-				const text = r.payload?.text ?? "";
-				if (!text) return;
-				const lines = text.split(/\n+/);
-				for (const ln of lines) {
-					for (const { key, rx } of patterns) {
-						const m = ln.match(rx);
-						const valStr = m?.[2] ?? m?.[3];
-						if (!m || !valStr) continue;
-						const normalized = Number(valStr.replace(/[\.]/g, "").replace(",", "."));
-						if (!Number.isFinite(normalized) || normalized <= 0) continue;
+		// Mapa agregado: mantém o menor valor e a melhor referência
+		const feeMap = new Map<
+			string,
+			{ valor: number; source: string; score: number }
+		>();
+		results.forEach((r, idx) => {
+			const text = r.payload?.text ?? "";
+			if (!text) return;
+			const lines = text.split(/\n+/);
+			for (const ln of lines) {
+				for (const { key, rx } of patterns) {
+					const m = ln.match(rx);
+					const valStr = m?.[2] ?? m?.[3];
+					if (!m || !valStr) continue;
+					const normalized = Number(
+						valStr.replace(/[\.]/g, "").replace(",", "."),
+					);
+					if (!Number.isFinite(normalized) || normalized <= 0) continue;
 
-						const prev = feeMap.get(key);
-						const source = r.payload?.docName || `Document ${idx + 1}`;
-						const score = typeof r.score === "number" ? r.score : 0;
-						if (!prev || normalized < prev.valor || (normalized === prev.valor && score > prev.score)) {
-							feeMap.set(key, { valor: normalized, source, score });
-						}
+					const prev = feeMap.get(key);
+					const source = r.payload?.docName || `Document ${idx + 1}`;
+					const score = typeof r.score === "number" ? r.score : 0;
+					if (
+						!prev ||
+						normalized < prev.valor ||
+						(normalized === prev.valor && score > prev.score)
+					) {
+						feeMap.set(key, { valor: normalized, source, score });
 					}
 				}
-			});
+			}
+		});
 
-			const fees = Array.from(feeMap.entries()).map(([tipo, v]) => ({ tipo, valor: v.valor, source: v.source, score: v.score }));
-			return { ok: true as const, fees };
-		},
+		const fees = Array.from(feeMap.entries()).map(([tipo, v]) => ({
+			tipo,
+			valor: v.valor,
+			source: v.source,
+			score: v.score,
+		}));
+		return { ok: true as const, fees };
+	},
 });
-
 
 // consultar no banco de dados
 export const financeiroListBoletos = createTool({
-    name: "financeiro_list_boletos",
-    description: "lista boletos emitidos com status",
-    parameters: z.object({
-        status: z.enum(["ABERTO", "PAGO", "ATRASADO"]).optional(),
-        startDate: z.string().optional().describe("início do período (ISO)"),
-        endDate: z.string().optional().describe("fim do período (ISO)"),
-    }),
-    execute: async ({ status, startDate, endDate }) => {
-        const mapUiToDb = (s: "ABERTO" | "PAGO" | "ATRASADO") =>
-            s === "PAGO" ? "PAIED" : s === "ATRASADO" ? "EXPIRED" : "PENDENT";
-        const mapDbToUi = (s: string) =>
-            s === "PAIED" ? ("PAGO" as const) : s === "EXPIRED" ? ("ATRASADO" as const) : ("ABERTO" as const);
+	name: "financeiro_list_boletos",
+	description: "lista boletos emitidos com status",
+	parameters: z.object({
+		status: z.enum(["ABERTO", "PAGO", "ATRASADO"]).optional(),
+		startDate: z.string().optional().describe("início do período (ISO)"),
+		endDate: z.string().optional().describe("fim do período (ISO)"),
+	}),
+	execute: async ({ status, startDate, endDate }) => {
+		const mapUiToDb = (s: "ABERTO" | "PAGO" | "ATRASADO") =>
+			s === "PAGO" ? "PAIED" : s === "ATRASADO" ? "EXPIRED" : "PENDENT";
+		const mapDbToUi = (s: string) =>
+			s === "PAIED"
+				? ("PAGO" as const)
+				: s === "EXPIRED"
+					? ("ATRASADO" as const)
+					: ("ABERTO" as const);
 
-        const where: any = {};
-        if (status) where.status = mapUiToDb(status);
+		const where: Record<string, unknown> = {};
+		if (status) where.status = mapUiToDb(status);
 
-        const gte = startDate ? new Date(startDate) : undefined;
-        const lte = endDate ? new Date(endDate) : undefined;
-        const validGte = gte && !isNaN(gte.getTime()) ? gte : undefined;
-        const validLte = lte && !isNaN(lte.getTime()) ? lte : undefined;
-        if (validGte || validLte) {
-            where.expiredIn = { ...(validGte ? { gte: validGte } : {}), ...(validLte ? { lte: validLte } : {}) };
-        }
+		const gte = startDate ? new Date(startDate) : undefined;
+		const lte = endDate ? new Date(endDate) : undefined;
+		const validGte = gte && !Number.isNaN(gte.getTime()) ? gte : undefined;
+		const validLte = lte && !Number.isNaN(lte.getTime()) ? lte : undefined;
+		if (validGte || validLte) {
+			where.expiredIn = {
+				...(validGte ? { gte: validGte } : {}),
+				...(validLte ? { lte: validLte } : {}),
+			};
+		}
 
-        const rows = await prisma.boletos.findMany({ where, orderBy: { createdAt: "desc" } });
-        return {
-            boletos: rows.map((b) => ({
-                linhaDigitavel: b.typedLine,
-                dueDate: b.expiredIn.toISOString(),
-                status: mapDbToUi(b.status),
-            })),
-        };
-    },
+		const rows = await prisma.boletos.findMany({
+			where,
+			orderBy: { createdAt: "desc" },
+		});
+		return {
+			boletos: rows.map((b) => ({
+				linhaDigitavel: b.typedLine,
+				dueDate: b.expiredIn.toISOString(),
+				status: mapDbToUi(b.status),
+			})),
+		};
+	},
 });
-
 
 export const financeiroGetPaymentHistory = createTool({
 	name: "financeiro_get_payment_history",
@@ -382,7 +410,6 @@ export const financeiroGetPaymentHistory = createTool({
 	},
 });
 
-
 export const financeiroGetScholarshipInfo = createTool({
 	name: "financeiro_get_scholarship_info",
 	description: "informa critérios e descontos de bolsas de estudo",
@@ -403,8 +430,12 @@ export const financeiroListConvenios = createTool({
 	parameters: z.object({}),
 	execute: async () => {
 		// Buscar em documentos via Qdrant e extrair convênios (empresa + % desconto)
-		const query = "convênio convenio parceria empresa parceira desconto % acordo corporativo";
-		const emb = await openaiClient.embeddings.create({ model: EMBED_MODEL, input: query });
+		const query =
+			"convênio convenio parceria empresa parceira desconto % acordo corporativo";
+		const emb = await openaiClient.embeddings.create({
+			model: EMBED_MODEL,
+			input: query,
+		});
 		const vector = emb.data[0].embedding as number[];
 		const results = (await qdrant.search(QDRANT_COLLECTION, {
 			vector,
@@ -416,7 +447,10 @@ export const financeiroListConvenios = createTool({
 					{ key: "kind", match: { value: "CSV" } },
 				],
 			},
-		})) as Array<{ payload?: { text?: string; docName?: string }; score?: number }>;
+		})) as Array<{
+			payload?: { text?: string; docName?: string };
+			score?: number;
+		}>;
 
 		const convMap = new Map<string, number>();
 		const companyRegexes = [
@@ -436,7 +470,7 @@ export const financeiroListConvenios = createTool({
 				let empresa: string | undefined;
 				for (const crx of companyRegexes) {
 					const m = ln.match(crx);
-					if (m && m[1]) {
+					if (m?.[1]) {
 						empresa = m[1].trim();
 						break;
 					}
@@ -446,7 +480,7 @@ export const financeiroListConvenios = createTool({
 				let pct: number | undefined;
 				for (const drx of discountRegexes) {
 					const m = ln.match(drx);
-					if (m && m[1]) {
+					if (m?.[1]) {
 						const n = Number(m[1].replace(/[\.]/g, "").replace(",", "."));
 						if (Number.isFinite(n) && n > 0) {
 							pct = n;
@@ -462,7 +496,9 @@ export const financeiroListConvenios = createTool({
 			}
 		}
 
-		const convenios = Array.from(convMap.entries()).map(([empresa, desconto]) => ({ empresa, desconto }));
+		const convenios = Array.from(convMap.entries()).map(
+			([empresa, desconto]) => ({ empresa, desconto }),
+		);
 		return { convenios };
 	},
 });
@@ -475,31 +511,31 @@ const negotiationParams = z.object({
 
 // registra no banco de dados
 export const financeiroRegisterNegotiation = createTool({
-    name: "financeiro_registrar_negociacao",
-    description: "registra negociações ou parcelamentos de um plano",
-    parameters: negotiationParams,
-    execute: async ({ planId, detalhes, parcelas }) => {
-        // 1) valida existência do plano
-        const plan = await prisma.plans.findUnique({ where: { id: planId } });
-        if (!plan) return { ok: false as const, error: "plano não encontrado" };
+	name: "financeiro_registrar_negociacao",
+	description: "registra negociações ou parcelamentos de um plano",
+	parameters: negotiationParams,
+	execute: async ({ planId, detalhes, parcelas }) => {
+		// 1) valida existência do plano
+		const plan = await prisma.plans.findUnique({ where: { id: planId } });
+		if (!plan) return { ok: false as const, error: "plano não encontrado" };
 
-        // 2) garante tabela histórica (idempotente)
-        await prisma.$executeRaw`CREATE TABLE IF NOT EXISTS plan_negotiations (
+		// 2) garante tabela histórica (idempotente)
+		await prisma.$executeRaw`CREATE TABLE IF NOT EXISTS plan_negotiations (
             id TEXT PRIMARY KEY,
             plan_id TEXT NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
             details TEXT NOT NULL,
             parcelas INT,
             created_at TIMESTAMPTZ NOT NULL DEFAULT now()
         )`;
-        await prisma.$executeRaw`CREATE INDEX IF NOT EXISTS plan_negotiations_plan_idx ON plan_negotiations(plan_id)`;
+		await prisma.$executeRaw`CREATE INDEX IF NOT EXISTS plan_negotiations_plan_idx ON plan_negotiations(plan_id)`;
 
-        // 3) insere registro histórico
-        const id = randomUUID();
-        await prisma.$executeRaw`
+		// 3) insere registro histórico
+		const id = randomUUID();
+		await prisma.$executeRaw`
             INSERT INTO plan_negotiations (id, plan_id, details, parcelas)
             VALUES (${id}, ${planId}, ${detalhes}, ${parcelas ?? null})
         `;
 
-        return { ok: true as const, negotiationId: id };
-    },
+		return { ok: true as const, negotiationId: id };
+	},
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -3,13 +3,13 @@ import { prisma } from "./prisma";
 
 // Ensures the `instance` belongs to the user from header x-user-id
 export async function ensureInstanceAccess(c: Context, instance: string) {
-  const userId = c.req.header("x-user-id");
-  if (!userId) throw new Error("missing x-user-id header");
+	const userId = c.req.header("x-user-id");
+	if (!userId) throw new Error("missing x-user-id header");
 
-  const ownership = await prisma.whatsappNumbers.findFirst({
-    where: { userId, instance },
-    select: { id: true, instance: true },
-  });
-  if (!ownership) throw new Error("instance not allowed for this user");
-  return { userId, evoInstance: ownership.instance };
+	const ownership = await prisma.whatsappNumbers.findFirst({
+		where: { userId, instance },
+		select: { id: true, instance: true },
+	});
+	if (!ownership) throw new Error("instance not allowed for this user");
+	return { userId, evoInstance: ownership.instance };
 }

--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -1,16 +1,15 @@
 import { PostgresStorage } from "@voltagent/postgres";
 
 const connection =
-  process.env.MEMORY_DATABASE_URL ||
-  process.env.DATABASE_URL ||
-  "postgresql://postgres:postgres@localhost:5432/voltagent";
+	process.env.MEMORY_DATABASE_URL ||
+	process.env.DATABASE_URL ||
+	"postgresql://postgres:postgres@localhost:5432/voltagent";
 
 const storageLimit = Number(process.env.MEMORY_STORAGE_LIMIT || 100);
 
 export const memoryStorage = new PostgresStorage({
-  connection,
-  maxConnections: 10,
-  tablePrefix: "voltagent_memory",
-  storageLimit,
+	connection,
+	maxConnections: 10,
+	tablePrefix: "voltagent_memory",
+	storageLimit,
 });
-


### PR DESCRIPTION
## Summary
- track agent per conversation in Prisma
- reuse stored agent when routing new chat messages
- expose assigned agent when listing conversation messages

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx prisma migrate dev --name conversation_agents` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68b7345b5f9083288054c1c49ada7008