### PR TITLE
chore: prepare voltagent cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=builder --chown=nodejs:nodejs /app/dist ./dist
 RUN mkdir -p /data && chown -R nodejs:nodejs /data
 ENV FILES_DIR=/data
 
+RUN mkdir -p /app/.voltagent/cache && chown -R nodejs:nodejs /app/.voltagent
 USER nodejs
 EXPOSE 3141
 


### PR DESCRIPTION
## Summary
- ensure /app/.voltagent cache exists with proper ownership in Dockerfile

## Testing
- `npm test` (fails: Missing script "test")
- `docker-compose build` (fails: Error while fetching server API version: Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68b853d35d9c8328b2bab82190a1c2c2