### PR TITLE
feat: enforce memory database URL

### DIFF
--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -1,9 +1,12 @@
 import { PostgresStorage } from "@voltagent/postgres";
 
-const connection =
-	process.env.MEMORY_DATABASE_URL ||
-	process.env.DATABASE_URL ||
-	"postgresql://postgres:postgres@localhost:5432/voltagent";
+const connection = process.env.MEMORY_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!connection) {
+	throw new Error(
+		"MEMORY_DATABASE_URL is required. Please provide the MEMORY_DATABASE_URL environment variable.",
+	);
+}
 
 const storageLimit = Number(process.env.MEMORY_STORAGE_LIMIT || 100);
 


### PR DESCRIPTION
## Summary
- require explicit MEMORY_DATABASE_URL with error when absent
- drop localhost fallback

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b88af097fc8328b116e3d45433aaed