### PR TITLE
docs: add env template and config guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# Server configuration
+PORT=3141
+
+# PostgreSQL connection strings
+DATABASE_URL=postgresql://user:password@localhost:5432/voltagent
+MEMORY_DATABASE_URL=postgresql://user:password@localhost:5432/voltagent_memory
+
+# Memory settings
+MEMORY_STORAGE_LIMIT=100
+FILES_DIR=./data
+
+# OpenAI settings
+OPENAI_API_KEY=
+EMBED_MODEL=text-embedding-3-small
+
+# VoltOps (optional)
+VOLTAGENT_PUBLIC_KEY=
+VOLTAGENT_SECRET_KEY=
+
+# Qdrant vector database
+QDRANT_URL=http://localhost:6333
+QDRANT_COLLECTION=voltagent-knowledge-base
+QDRANT_API_KEY=
+
+# External providers (optional)
+PINECONE_API_KEY=
+COHERE_API_KEY=
+
+# Evolution service (optional)
+EVOLUTION_URL=
+EVO_API_KEY=
+EVOLUTION_SENDTEXT_PATH=/message/sendText
+EVOLUTION_APIKEY_IN=header

--- a/README.md
+++ b/README.md
@@ -27,22 +27,29 @@ cd my-agent-app
 # Install dependencies
 npm install
 
-# Copy environment variables
+# Copy environment variables template
 cp .env.example .env
 ```
 
 ### Configuration
 
-Edit `.env` file with your API keys:
+Edit `.env` using the `.env.example` template. Key variables include:
 
-```env
-OPENAI_API_KEY=your-api-key-here
+- `DATABASE_URL` – PostgreSQL connection for chat and workflow data
+- `MEMORY_DATABASE_URL` – PostgreSQL connection for long-term memory
+- `OPENAI_API_KEY` – API key for OpenAI models
+- `QDRANT_URL` – Base URL of your Qdrant instance
+- `QDRANT_COLLECTION` – Qdrant collection name
+- `QDRANT_API_KEY` – (optional) Qdrant API key
+- `PORT` – Port for the HTTP server (defaults to 3141)
+- `VOLTAGENT_PUBLIC_KEY` / `VOLTAGENT_SECRET_KEY` – VoltOps keys for tracing (optional)
+- `MEMORY_STORAGE_LIMIT` – Maximum memory items to keep (optional)
+- `FILES_DIR` – Directory for uploaded files (optional)
+- `EMBED_MODEL` – Embedding model used for vectorization (optional)
+- `PINECONE_API_KEY`, `COHERE_API_KEY` – Additional provider keys (optional)
+- `EVOLUTION_URL`, `EVO_API_KEY`, `EVOLUTION_SENDTEXT_PATH`, `EVOLUTION_APIKEY_IN` – Evolution integration settings (optional)
 
-# VoltOps Platform (Optional)
-# Get your keys at https://console.voltagent.dev/tracing-setup
-# VOLTAGENT_PUBLIC_KEY=your-public-key
-# VOLTAGENT_SECRET_KEY=your-secret-key
-```
+The same variables are used for local development and the Docker setup.
 
 ### Running the Application
 
@@ -158,7 +165,7 @@ docker build -t my-agent-app .
 # Run container
 docker run -p 3141:3141 --env-file .env my-agent-app
 
-# Or use docker-compose
+# Or use docker-compose (reads variables from .env)
 docker-compose up
 ```
 


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for database, Qdrant, and API keys
- document all environment variables in README
- note that Docker and local development share the same `.env`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b88c10c3008328b89adcf99ddf1546