### PR TITLE
feat: add JWT-based authentication

### DIFF
--- a/src/endpoints/user.ts
+++ b/src/endpoints/user.ts
@@ -4,97 +4,97 @@ import { loginUser } from "../services/login";
 import { createInstance } from "../services/users";
 
 export const userEndpoints: CustomEndpointDefinition[] = [
-  {
-    path: "/api/login",
-    method: "post" as const,
-    handler: async (c: Context): Promise<Response> => {
-      try {
-        const body = await c.req.json().catch(() => null);
-        if (!body || typeof body !== "object")
-          return c.json({ success: false, message: "Invalid JSON body" }, 400);
-        const { email, password } = body as {
-          email?: string;
-          password?: string;
-        };
-        if (!email || !password)
-          return c.json(
-            { success: false, message: "email and password are required" },
-            400
-          );
-        const result = await loginUser(email, password);
-        if (!result.success) {
-          return c.json(
-            {
-              success: false,
-              message: "Invalid Credentials",
-            },
-            401
-          );
-        }
+	{
+		path: "/api/login",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			try {
+				const body = await c.req.json().catch(() => null);
+				if (!body || typeof body !== "object")
+					return c.json({ success: false, message: "Invalid JSON body" }, 400);
+				const { email, password } = body as {
+					email?: string;
+					password?: string;
+				};
+				if (!email || !password)
+					return c.json(
+						{ success: false, message: "email and password are required" },
+						400,
+					);
+				const result = await loginUser(email, password);
+				if (!result.success) {
+					return c.json(
+						{
+							success: false,
+							message: "Invalid Credentials",
+						},
+						401,
+					);
+				}
 
-        return c.json(
-          {
-            success: true,
-            message: "Login successful",
-            data: result.user,
-          },
-          200
-        );
-      } catch (error: unknown) {
-        return c.json(
-          {
-            success: false,
-            message:
-              error instanceof Error ? error.message : "Invalid request body",
-            data: null,
-          },
-          400
-        );
-      }
-    },
-    description: "[publica] busca email para login",
-  },
+				return c.json(
+					{
+						success: true,
+						message: "Login successful",
+						data: { token: result.token },
+					},
+					200,
+				);
+			} catch (error: unknown) {
+				return c.json(
+					{
+						success: false,
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
+						data: null,
+					},
+					400,
+				);
+			}
+		},
+		description: "[publica] busca email para login",
+	},
 
-  {
-    path: "/api/instance",
-    method: "post" as const,
-    handler: async (c: Context): Promise<Response> => {
-      try {
-        const body = await c.req.json().catch(() => null);
-        if (!body || typeof body !== "object")
-          return c.json({ success: false, message: "Invalid JSON body" }, 400);
-        const { instance, userId } = body as {
-          instance?: string;
-          userId?: string;
-        };
-        if (!instance || !userId)
-          return c.json(
-            { success: false, message: "instance and userId are required" },
-            400
-          );
-        const createdInstance = await createInstance(instance, userId);
+	{
+		path: "/api/instance",
+		method: "post" as const,
+		handler: async (c: Context): Promise<Response> => {
+			try {
+				const body = await c.req.json().catch(() => null);
+				if (!body || typeof body !== "object")
+					return c.json({ success: false, message: "Invalid JSON body" }, 400);
+				const { instance, userId } = body as {
+					instance?: string;
+					userId?: string;
+				};
+				if (!instance || !userId)
+					return c.json(
+						{ success: false, message: "instance and userId are required" },
+						400,
+					);
+				const createdInstance = await createInstance(instance, userId);
 
-        console.log("user encontrado:", instance);
-        return c.json(
-          {
-            success: true,
-            message: "instance created successful",
-            data: createdInstance,
-          },
-          201
-        );
-      } catch (error: unknown) {
-        return c.json(
-          {
-            success: false,
-            message:
-              error instanceof Error ? error.message : "Invalid request body",
-            data: null,
-          },
-          400
-        );
-      }
-    },
-    description: "[publica] cria uma instancia no banco",
-  },
+				console.log("user encontrado:", instance);
+				return c.json(
+					{
+						success: true,
+						message: "instance created successful",
+						data: createdInstance,
+					},
+					201,
+				);
+			} catch (error: unknown) {
+				return c.json(
+					{
+						success: false,
+						message:
+							error instanceof Error ? error.message : "Invalid request body",
+						data: null,
+					},
+					400,
+				);
+			}
+		},
+		description: "[publica] cria uma instancia no banco",
+	},
 ];

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -1,21 +1,30 @@
+import { SignJWT } from "jose";
 import { getUserbyEmail } from "../repositories/user-repository";
 import { verifyPassword } from "../utils/password";
 
-interface LoginResult{
-	success:boolean;
+interface LoginResult {
+	success: boolean;
 	user?: Awaited<ReturnType<typeof getUserbyEmail>>;
+	token?: string;
 }
 
-
-export const loginUser = async (email: string, password: string):Promise<LoginResult> => {
-	
+export const loginUser = async (
+	email: string,
+	password: string,
+): Promise<LoginResult> => {
 	const queryUser = await getUserbyEmail(email);
 	if (!queryUser) return { success: false };
 
 	const passwordMatch = await verifyPassword(password, queryUser.passwordHash);
 	if (!passwordMatch) {
-		return {success:false};
+		return { success: false };
 	}
-	// password passado
-	return {success:true, user:queryUser}
+
+	const secret = new TextEncoder().encode(process.env.JWT_SECRET || "");
+	const token = await new SignJWT({ userId: queryUser.id })
+		.setProtectedHeader({ alg: "HS256" })
+		.setExpirationTime("1h")
+		.sign(secret);
+
+	return { success: true, user: queryUser, token };
 };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,28 +1,32 @@
 import type { Context } from "hono";
+import { jwtVerify } from "jose";
 import { prisma } from "./prisma";
 
-// Attempt to resolve user from headers: prefer x-user-id; fallback to Authorization (Bearer <userId> or <userId>)
-export function getUserIdFromHeaders(c: Context): string | null {
-  const direct = c.req.header("x-user-id");
-  if (direct && direct.trim().length > 0) return direct.trim();
-  const auth = c.req.header("authorization") || c.req.header("Authorization");
-  if (!auth) return null;
-  const val = auth.trim();
-  if (!val) return null;
-  const bearer = /^Bearer\s+(.+)$/i.exec(val);
-  if (bearer && bearer[1]) return bearer[1].trim();
-  return val; // last resort: treat whole header as userId
+// Extract user id from Authorization: Bearer <token>
+export async function getUserIdFromHeaders(c: Context): Promise<string | null> {
+	const auth = c.req.header("authorization") || c.req.header("Authorization");
+	if (!auth) return null;
+	const match = /^Bearer\s+(.+)$/i.exec(auth.trim());
+	if (!match) return null;
+	try {
+		const secret = new TextEncoder().encode(process.env.JWT_SECRET || "");
+		const { payload } = await jwtVerify(match[1], secret);
+		const userId = payload.userId;
+		return typeof userId === "string" ? userId : null;
+	} catch {
+		return null;
+	}
 }
 
 // Ensures the `instance` belongs to the user obtained from headers
 export async function ensureInstanceAccess(c: Context, instance: string) {
-  const userId = getUserIdFromHeaders(c);
-  if (!userId) throw new Error("missing user credentials");
+	const userId = await getUserIdFromHeaders(c);
+	if (!userId) throw new Error("missing user credentials");
 
-  const ownership = await prisma.whatsappNumbers.findFirst({
-    where: { userId, instance },
-    select: { id: true, instance: true },
-  });
-  if (!ownership) throw new Error("instance not allowed for this user");
-  return { userId, evoInstance: ownership.instance };
+	const ownership = await prisma.whatsappNumbers.findFirst({
+		where: { userId, instance },
+		select: { id: true, instance: true },
+	});
+	if (!ownership) throw new Error("instance not allowed for this user");
+	return { userId, evoInstance: ownership.instance };
 }


### PR DESCRIPTION
## Summary
- generate JWT after password verification and return from login endpoint
- validate Authorization header with JWT_SECRET to extract userId
- update instance access checks to use verified userId

## Testing
- `npm run lint` *(fails: Found 39 errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea379d2c8328a9de6c13d3698acd